### PR TITLE
Adding check for redis object socket.

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -709,7 +709,9 @@ class WP_Object_Cache {
 
 		$this->redis = new Redis();
 		$this->redis->connect( $redis_server['host'], $redis_server['port'], 1, NULL, 100 ); # 1s timeout, 100ms delay between reconnections
-		if ( ! empty( $redis_server['auth'] ) ) {
+
+		// Add a test to make sure the $redis_server['auth'] & redis->socket exists
+		if ( ! empty( $redis_server['auth'] ) && ( isset($this->redis->socket) ) ) {
 			$this->redis->auth( $redis_server['auth'] );
 		}
 


### PR DESCRIPTION
Adding check for redis object socket to confirm that the Redis connection exists. I have a WP client who is getting occasional errors on the $this->redis->auth( $redis_server['auth'] ); line, with the Redis server "has gone away". Hopefully this will allow those to be headed off. This should also take care of the fatal errors that happen when a site is downgraded to a plan that does not include Redis.
