### PR TITLE
Better handle when Redis is unavailable or intermittent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ services:
     - redis-server
 
 before_script:
-    - echo 'extension = "redis.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION 
 
-script: phpunit
+script:
+	- phpunit
+	- echo 'extension = "redis.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+	- phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_script:
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION 
 
 script:
-	- phpunit
-	- echo 'extension = "redis.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-	- phpunit
+    - phpunit
+    - echo 'extension = "redis.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+    - phpunit

--- a/object-cache.php
+++ b/object-cache.php
@@ -753,6 +753,7 @@ if ( class_exists( 'Redis' ) ) {
 					$offset = isset( $arguments[1] ) && 'incrBy' === $name ? $arguments[1] : 1;
 					$val = $val + $offset;
 					return $val;
+				case 'decrBy':
 				case 'decr':
 					$val = $wp_object_cache->cache[ $arguments[0] ];
 					$offset = isset( $arguments[1] ) && 'decrBy' === $name ? $arguments[1] : 1;

--- a/object-cache.php
+++ b/object-cache.php
@@ -745,7 +745,14 @@ if ( class_exists( 'Redis' ) ) {
 	class WP_Redis {
 
 		public function __call( $name, $arguments ) {
+			global $wp_object_cache;
 			switch ( $name ) {
+				case 'incr':
+					$wp_object_cache->cache[ $arguments['id'] ]++;
+					return $wp_object_cache->cache[ $arguments['id'] ];
+				case 'decr':
+					$wp_object_cache->cache[ $arguments['id'] ]++;
+					return $wp_object_cache->cache[ $arguments['id'] ];
 				case 'delete':
 					return 1;
 			}

--- a/object-cache.php
+++ b/object-cache.php
@@ -707,7 +707,7 @@ class WP_Object_Cache {
 			}
 		}
 
-		$this->redis = new Redis();
+		$this->redis = new WP_Redis();
 		$this->redis->connect( $redis_server['host'], $redis_server['port'], 1, NULL, 100 ); # 1s timeout, 100ms delay between reconnections
 		if ( ! empty( $redis_server['auth'] ) ) {
 			$this->redis->auth( $redis_server['auth'] );
@@ -734,5 +734,29 @@ class WP_Object_Cache {
 	 */
 	function __destruct() {
 		return true;
+	}
+}
+
+if ( class_exists( 'Redis' ) ) {
+	class WP_Redis extends Redis {
+
+	}
+} else {
+	class WP_Redis {
+
+		public function __call( $name, $arguments ) {
+		}
+
+		public function __construct() {
+			add_action( 'admin_notices', array( $this, 'wp_action_admin_notices_warn_missing_redis' ) );
+		}
+
+		public function wp_action_admin_notices_warn_missing_redis() {
+			if ( ! current_user_can( 'manage_options' ) ) {
+				return;
+			}
+			echo '<div class="message error"><p>Alert! PHPRedis module is unavailable, which is required by WP Redis object cache.</p></div>';
+		}
+
 	}
 }

--- a/object-cache.php
+++ b/object-cache.php
@@ -708,6 +708,7 @@ class WP_Object_Cache {
 		}
 
 		$this->redis = new WP_Redis();
+		$this->redis->wp_object_cache = &$this;
 		$this->redis->connect( $redis_server['host'], $redis_server['port'], 1, NULL, 100 ); # 1s timeout, 100ms delay between reconnections
 		if ( ! empty( $redis_server['auth'] ) ) {
 			$this->redis->auth( $redis_server['auth'] );
@@ -745,23 +746,16 @@ if ( class_exists( 'Redis' ) ) {
 	class WP_Redis {
 
 		public function __call( $name, $arguments ) {
-			global $wp_object_cache;
 			switch ( $name ) {
 				case 'incr':
 				case 'incrBy':
-					if ( ! isset( $wp_object_cache->cache[ $arguments[0] ] ) ) {
-						return false;
-					}
-					$val = $wp_object_cache->cache[ $arguments[0] ];
+					$val = $this->wp_object_cache->cache[ $arguments[0] ];
 					$offset = isset( $arguments[1] ) && 'incrBy' === $name ? $arguments[1] : 1;
 					$val = $val + $offset;
 					return $val;
 				case 'decrBy':
 				case 'decr':
-					if ( ! isset( $wp_object_cache->cache[ $arguments[0] ] ) ) {
-						return false;
-					}
-					$val = $wp_object_cache->cache[ $arguments[0] ];
+					$val = $this->wp_object_cache->cache[ $arguments[0] ];
 					$offset = isset( $arguments[1] ) && 'decrBy' === $name ? $arguments[1] : 1;
 					$val = $val - $offset;
 					return $val;

--- a/object-cache.php
+++ b/object-cache.php
@@ -761,6 +761,8 @@ if ( class_exists( 'Redis' ) ) {
 					return $val;
 				case 'delete':
 					return 1;
+				case 'exists':
+					return false;
 			}
 		}
 

--- a/object-cache.php
+++ b/object-cache.php
@@ -748,11 +748,16 @@ if ( class_exists( 'Redis' ) ) {
 			global $wp_object_cache;
 			switch ( $name ) {
 				case 'incr':
-					$wp_object_cache->cache[ $arguments['id'] ]++;
-					return $wp_object_cache->cache[ $arguments['id'] ];
+				case 'incrBy':
+					$val = $wp_object_cache->cache[ $arguments[0] ];
+					$offset = isset( $arguments[1] ) && 'incrBy' === $name ? $arguments[1] : 1;
+					$val = $val + $offset;
+					return $val;
 				case 'decr':
-					$wp_object_cache->cache[ $arguments['id'] ]++;
-					return $wp_object_cache->cache[ $arguments['id'] ];
+					$val = $wp_object_cache->cache[ $arguments[0] ];
+					$offset = isset( $arguments[1] ) && 'decrBy' === $name ? $arguments[1] : 1;
+					$val = $val - $offset;
+					return $val;
 				case 'delete':
 					return 1;
 			}

--- a/object-cache.php
+++ b/object-cache.php
@@ -745,6 +745,10 @@ if ( class_exists( 'Redis' ) ) {
 	class WP_Redis {
 
 		public function __call( $name, $arguments ) {
+			switch ( $name ) {
+				case 'delete':
+					return 1;
+			}
 		}
 
 		public function __construct() {

--- a/object-cache.php
+++ b/object-cache.php
@@ -749,12 +749,18 @@ if ( class_exists( 'Redis' ) ) {
 			switch ( $name ) {
 				case 'incr':
 				case 'incrBy':
+					if ( ! isset( $wp_object_cache->cache[ $arguments[0] ] ) ) {
+						return false;
+					}
 					$val = $wp_object_cache->cache[ $arguments[0] ];
 					$offset = isset( $arguments[1] ) && 'incrBy' === $name ? $arguments[1] : 1;
 					$val = $val + $offset;
 					return $val;
 				case 'decrBy':
 				case 'decr':
+					if ( ! isset( $wp_object_cache->cache[ $arguments[0] ] ) ) {
+						return false;
+					}
 					$val = $wp_object_cache->cache[ $arguments[0] ];
 					$offset = isset( $arguments[1] ) && 'decrBy' === $name ? $arguments[1] : 1;
 					$val = $val - $offset;


### PR DESCRIPTION
* [x] Fall back to standard WP Object Cache when Redis is unavailable.
* [ ] Fall back to standard WP Object Cache when Redis is disconnected.
* [x] Show an admin notice when Redis is unavailable but is expected to be.

See #4, #7, #9