### PR TITLE
Accommodate `WP_DEVELOP_DIR` environment variable being set

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,9 @@ require_once $_tests_dir . '/includes/functions.php';
 
 $_core_dir = getenv( 'WP_CORE_DIR' );
 if ( ! $_core_dir ) {
+	$_core_dir = getenv( 'WP_DEVELOP_DIR' ) . '/src/';
+}
+if ( ! $_core_dir ) {
 	$_core_dir = '/tmp/wordpress';
 }
 


### PR DESCRIPTION
It can be used to specify where a copy of WordPress with tests is already checked out to.