### PR TITLE
Add 'socket error on read socket' as valid retry exception

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -735,7 +735,9 @@ class WP_Object_Cache {
 				$retval = call_user_func_array( array( $this->redis, $method ), $arguments );
 				return $retval;
 			} catch( RedisException $e ) {
-				if ( in_array( $e->getMessage(), array( 'Connection closed', 'Redis server went away' ) ) ) {
+				$retry_exception_messages = array( 'socket error on read socket', 'Connection closed', 'Redis server went away' );
+				$retry_exception_messages = apply_filters( 'wp_redis_retry_exception_messages', $retry_exception_messages );
+				if ( in_array( $e->getMessage(), $retry_exception_messages ) ) {
 					trigger_error( 'WP Redis: ' . $e->getMessage(), E_WARNING );
 					// Attempt to refresh the connection if it was successfully established once
 					// $this->is_redis_connected will be set inside _connect_redis()


### PR DESCRIPTION
Also makes the exception messages filterable, so implementers can easily
catch other messages

Fixes #31