### PR TITLE
Properly handle exceptions thrown by PHPUnit to continue running tests

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -307,6 +307,11 @@ class WP_Object_Cache {
 	var $do_redis_failback_flush = false;
 
 	/**
+	 * The last triggered error
+	 */
+	var $last_triggered_error = '';
+
+	/**
 	 * Adds data to the cache if it doesn't already exist.
 	 *
 	 * @uses WP_Object_Cache::_exists Checks to see if the cache already has data.
@@ -738,7 +743,12 @@ class WP_Object_Cache {
 				$retry_exception_messages = array( 'socket error on read socket', 'Connection closed', 'Redis server went away' );
 				$retry_exception_messages = apply_filters( 'wp_redis_retry_exception_messages', $retry_exception_messages );
 				if ( in_array( $e->getMessage(), $retry_exception_messages ) ) {
-					trigger_error( 'WP Redis: ' . $e->getMessage(), E_USER_WARNING );
+					try {
+						$this->last_triggered_error = 'WP Redis: ' . $e->getMessage();
+						trigger_error( $this->last_triggered_error, E_USER_WARNING );
+					} catch( PHPUnit_Framework_Error_Warning $e ) {
+						// We'll inspect this in the test
+					}
 					// Attempt to refresh the connection if it was successfully established once
 					// $this->is_redis_connected will be set inside _connect_redis()
 					if ( $this->_connect_redis() ) {

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -32,12 +32,8 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertTrue( $this->cache->redis->IsConnected() );
 	}
 
-	/**
-	 * @expectedException PHPUnit_Framework_Error_Warning
-	 */
 	public function test_redis_reload_connection_closed() {
 		if ( ! class_exists( 'Redis' ) ) {
-			trigger_error( 'Mock error so PHPUnit still passes when this test is skipped.', E_WARNING );
 			$this->markTestSkipped( 'PHPRedis extension not available.' );
 		}
 		// Connection is live
@@ -50,19 +46,19 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertTrue( $this->cache->is_redis_connected );
 		$this->assertFalse( $this->cache->redis->IsConnected() );
 		// Reload occurs with set()
-		$this->cache->set( 'foo', 'banana' );
+		try {
+			$this->cache->set( 'foo', 'banana' );
+		} catch ( Exception $e ) {
+			$this->assertEquals( 'WP Redis: Connection closed', $e->getMessage() );
+		}
 		$this->assertEquals( 'banana', $this->cache->get( 'foo' ) );
 		$this->assertTrue( $this->cache->is_redis_connected );
 		$this->assertTrue( $this->cache->redis->IsConnected() );
 	}
 
-	/**
-	 * @expectedException PHPUnit_Framework_Error_Warning
-	 */
 	public function test_redis_reload_force_cache_flush() {
 		global $wpdb, $redis_server;
 		if ( ! class_exists( 'Redis' ) ) {
-			trigger_error( 'Mock error so PHPUnit still passes when this test is skipped.', E_WARNING );
 			$this->markTestSkipped( 'PHPRedis extension not available.' );
 		}
 		$this->assertFalse( (bool) $wpdb->get_results( "SELECT option_value FROM {$wpdb->options} WHERE option_name='wp_redis_do_redis_failback_flush'" ) );
@@ -72,7 +68,15 @@ class CacheTest extends WP_UnitTestCase {
 		$redis_server['port'] = 9999;
 		$this->cache->redis->connect( $redis_server['host'], $redis_server['port'], 1, NULL, 100 );
 		// Setting cache value when redis connection fails saves wakeup flush
-		$this->cache->set( 'foo', 'bar' );
+		try {
+			$this->cache->set( 'foo', 'bar' );
+		} catch ( Exception $e ) {
+			$this->assertEquals( 'WP Redis: Redis server went away', $e->getMessage() );
+			// Because an exception was thrown (and code execution was broken), we need to mock
+			// the behavior the plugin would've exhibited
+			$this->cache->is_redis_connected = false;
+			$this->cache->set( 'foo', 'bar' );
+		}
 		$this->assertEquals( "INSERT INTO `{$wpdb->options}` (`option_name`, `option_value`) VALUES ('wp_redis_do_redis_failback_flush', '1')", $wpdb->last_query );
 		$this->assertTrue( (bool) $wpdb->get_results( "SELECT option_value FROM {$wpdb->options} WHERE option_name='wp_redis_do_redis_failback_flush'" ) );
 		$this->assertTrue( $this->cache->do_redis_failback_flush );

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -67,7 +67,7 @@ class CacheTest extends WP_UnitTestCase {
 		// Setting cache value when redis connection fails saves wakeup flush
 		$this->cache->set( 'foo', 'bar' );
 		$this->assertEquals( 'WP Redis: Redis server went away', $this->cache->last_triggered_error );
-		$this->assertEquals( "INSERT IGNORE INTO `{$wpdb->options}` (`option_name`, `option_value`) VALUES ('wp_redis_do_redis_failback_flush', '1')", $wpdb->last_query );
+		$this->assertEquals( "INSERT IGNORE INTO {$wpdb->options} (option_name,option_value) VALUES ('wp_redis_do_redis_failback_flush',1)", $wpdb->last_query );
 		$this->assertTrue( (bool) $wpdb->get_results( "SELECT option_value FROM {$wpdb->options} WHERE option_name='wp_redis_do_redis_failback_flush'" ) );
 		$this->assertTrue( $this->cache->do_redis_failback_flush );
 		$this->assertEquals( 'bar', $this->cache->get( 'foo' ) );

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -46,11 +46,8 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertTrue( $this->cache->is_redis_connected );
 		$this->assertFalse( $this->cache->redis->IsConnected() );
 		// Reload occurs with set()
-		try {
-			$this->cache->set( 'foo', 'banana' );
-		} catch ( Exception $e ) {
-			$this->assertEquals( 'WP Redis: Connection closed', $e->getMessage() );
-		}
+		$this->cache->set( 'foo', 'banana' );
+		$this->assertEquals( 'WP Redis: Connection closed', $this->cache->last_triggered_error );
 		$this->assertEquals( 'banana', $this->cache->get( 'foo' ) );
 		$this->assertTrue( $this->cache->is_redis_connected );
 		$this->assertTrue( $this->cache->redis->IsConnected() );
@@ -68,15 +65,8 @@ class CacheTest extends WP_UnitTestCase {
 		$redis_server['port'] = 9999;
 		$this->cache->redis->connect( $redis_server['host'], $redis_server['port'], 1, NULL, 100 );
 		// Setting cache value when redis connection fails saves wakeup flush
-		try {
-			$this->cache->set( 'foo', 'bar' );
-		} catch ( Exception $e ) {
-			$this->assertEquals( 'WP Redis: Redis server went away', $e->getMessage() );
-			// Because an exception was thrown (and code execution was broken), we need to mock
-			// the behavior the plugin would've exhibited
-			$this->cache->is_redis_connected = false;
-			$this->cache->set( 'foo', 'bar' );
-		}
+		$this->cache->set( 'foo', 'bar' );
+		$this->assertEquals( 'WP Redis: Redis server went away', $this->cache->last_triggered_error );
 		$this->assertEquals( "INSERT INTO `{$wpdb->options}` (`option_name`, `option_value`) VALUES ('wp_redis_do_redis_failback_flush', '1')", $wpdb->last_query );
 		$this->assertTrue( (bool) $wpdb->get_results( "SELECT option_value FROM {$wpdb->options} WHERE option_name='wp_redis_do_redis_failback_flush'" ) );
 		$this->assertTrue( $this->cache->do_redis_failback_flush );


### PR DESCRIPTION
Previously, the exception would be thrown and the test would pass without all of the assertions being run.