### PR TITLE
Move build status indicator into Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 Back your WP Object Cache with Redis, a high-performance in-memory storage backend.
 
-[![Build Status](https://travis-ci.org/pantheon-systems/wp-redis.svg?branch=master)](https://travis-ci.org/pantheon-systems/wp-redis)
-
 ## Description ##
+
+[![Build Status](https://travis-ci.org/pantheon-systems/wp-redis.svg?branch=master)](https://travis-ci.org/pantheon-systems/wp-redis)
 
 For sites concerned with high traffic, speed for logged-in users, or dynamic pageloads, a high-speed and persistent object cache is a must. You also need something that can scale across multiple instances of your application, so using local file caches or APC are out.
 

--- a/readme.txt
+++ b/readme.txt
@@ -10,9 +10,9 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Back your WP Object Cache with Redis, a high-performance in-memory storage backend.
 
-[![Build Status](https://travis-ci.org/pantheon-systems/wp-redis.svg?branch=master)](https://travis-ci.org/pantheon-systems/wp-redis)
-
 == Description ==
+
+[![Build Status](https://travis-ci.org/pantheon-systems/wp-redis.svg?branch=master)](https://travis-ci.org/pantheon-systems/wp-redis)
 
 For sites concerned with high traffic, speed for logged-in users, or dynamic pageloads, a high-speed and persistent object cache is a must. You also need something that can scale across multiple instances of your application, so using local file caches or APC are out.
 


### PR DESCRIPTION
This ensures it doesn't clobber the short description on WordPress.org