### PR TITLE
Cut Travis' workload in half

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ notifications:
     on_success: never
     on_failure: change
 
+branches:
+  only:
+    - master
+
 matrix:
   include:
     - php: 5.3


### PR DESCRIPTION
Prevent duplicate builds from running on pull requests by only
triggering branch builds on master