### PR TITLE
Define WP_REDIS_USE_CACHE_GROUPS to use native cache groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ matrix:
     - php: 5.6
       env: WP_VERSION=latest PHP_REDIS=disabled
     - php: 5.6
+      env: WP_VERSION=latest PHP_REDIS=disabled WP_REDIS_USE_CACHE_GROUPS=true
+    - php: 5.6
+      env: WP_VERSION=latest PHP_REDIS=enabled WP_REDIS_USE_CACHE_GROUPS=true
+    - php: 5.6
       env: WP_VERSION=nightly PHP_REDIS=enabled
 
 services:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ This assumes you have a PHP environment with the [required PhpRedis extension](h
 
 3. Engage thrusters: you are now backing WP's Object Cache with Redis.
 4. (Optional) To use the same Redis server with multiple, discreet WordPress installs, you can use the `WP_CACHE_KEY_SALT` constant to define a unique salt for each install.
-5. (Optional) On an existing site previously using WordPress' transient cache, use WP-CLI to delete all (`%_transient_%`) transients from the options table: `wp transient delete-all`. WP Redis assumes responsibility for the transient cache.
+5. (Optional) To use true cache groups, with the ability to delete all keys for a given group, define the `WP_REDIS_USE_CACHE_GROUPS` constant to true. However, when enabled, the expiration value is not respected because expiration on group keys isn't a feature supported by Redis.
+6. (Optional) On an existing site previously using WordPress' transient cache, use WP-CLI to delete all (`%_transient_%`) transients from the options table: `wp transient delete-all`. WP Redis assumes responsibility for the transient cache.
 
 ## Frequently Asked Questions ##
 

--- a/object-cache.php
+++ b/object-cache.php
@@ -413,6 +413,9 @@ class WP_Object_Cache {
 			} else {
 				$existing -= $offset;
 			}
+			if ( $existing < 0 ) {
+				$existing = 0;
+			}
 			$this->_set_internal( $key, $group, $existing );
 			return $existing;
 		}

--- a/object-cache.php
+++ b/object-cache.php
@@ -905,6 +905,10 @@ class WP_Object_Cache {
 		$arguments = func_get_args();
 		array_shift( $arguments ); // ignore $method
 
+		if ( 'hIncrBy' === $method ) {
+			$group = array_pop( $arguments );
+		}
+
 		if ( $this->is_redis_connected ) {
 			try {
 				$retval = call_user_func_array( array( $this->redis, $method ), $arguments );
@@ -950,7 +954,7 @@ class WP_Object_Cache {
 					$val = $val + $offset;
 					return $val;
 				case 'hIncrBy':
-					$val = $this->_get_internal( $arguments[1], $arguments[3] );
+					$val = $this->_get_internal( $arguments[1], $group );
 					return $val + $arguments[2];
 				case 'decrBy':
 				case 'decr':

--- a/object-cache.php
+++ b/object-cache.php
@@ -920,6 +920,7 @@ class WP_Object_Cache {
 		$arguments = func_get_args();
 		array_shift( $arguments ); // ignore $method
 
+		// $group is intended for the failback, and isn't passed to the Redis callback
 		if ( 'hIncrBy' === $method ) {
 			$group = array_pop( $arguments );
 		}

--- a/object-cache.php
+++ b/object-cache.php
@@ -582,6 +582,9 @@ class WP_Object_Cache {
 			} else {
 				$existing += $offset;
 			}
+			if ( $existing < 0 ) {
+				$existing = 0;
+			}
 			$this->_set_internal( $key, $group, $existing );
 			return $existing;
 		}
@@ -589,9 +592,17 @@ class WP_Object_Cache {
 		if ( self::USE_GROUPS ) {
 			$redis_safe_group = $this->_key( '', $group );
 			$result = $this->_call_redis( 'hIncrBy', $redis_safe_group, $key, $offset, $group );
+			if ( $result < 0 ) {
+				$result = 0;
+				$this->_call_redis( 'hSet', $redis_safe_group, $key, $result );
+			}
 		} else {
 			$id = $this->_key( $key, $group );
 			$result = $this->_call_redis( 'incrBy', $id, $offset );
+			if ( $result < 0 ) {
+				$result = 0;
+				$this->_call_redis( 'set', $id, $result );
+			}
 		}
 
 		if ( is_int( $result ) ) {

--- a/object-cache.php
+++ b/object-cache.php
@@ -573,9 +573,6 @@ class WP_Object_Cache {
 		}
 
 		$offset = (int) $offset;
-		if ( $offset < 1 ) {
-			$offset = 1;
-		}
 
 		# If this isn't a persistant group, we have to sort this out ourselves, grumble grumble
 		if ( ! $this->_should_persist( $group ) ) {

--- a/object-cache.php
+++ b/object-cache.php
@@ -401,9 +401,6 @@ class WP_Object_Cache {
 		}
 
 		$offset = (int) $offset;
-		if ( $offset < 1 ) {
-			$offset = 1;
-		}
 
 		# If this isn't a persistant group, we have to sort this out ourselves, grumble grumble
 		if ( ! $this->_should_persist( $group ) ) {

--- a/object-cache.php
+++ b/object-cache.php
@@ -917,6 +917,7 @@ class WP_Object_Cache {
 					$val = $val - $offset;
 					return $val;
 				case 'delete':
+				case 'hDel':
 					return 1;
 				case 'flushAll':
 				case 'IsConnected':

--- a/object-cache.php
+++ b/object-cache.php
@@ -419,7 +419,7 @@ class WP_Object_Cache {
 
 		if ( self::USE_GROUPS ) {
 			$redis_safe_group = $this->_key( '', $group );
-			$result = $this->_call_redis( 'hIncrBy', $redis_safe_group, $key, -$offset );
+			$result = $this->_call_redis( 'hIncrBy', $redis_safe_group, $key, -$offset, $group );
 			if ( $result < 0 ) {
 				$result = 0;
 				$this->_call_redis( 'hSet', $redis_safe_group, $key, $result );
@@ -591,7 +591,7 @@ class WP_Object_Cache {
 
 		if ( self::USE_GROUPS ) {
 			$redis_safe_group = $this->_key( '', $group );
-			$result = $this->_call_redis( 'hIncrBy', $redis_safe_group, $key, $offset );
+			$result = $this->_call_redis( 'hIncrBy', $redis_safe_group, $key, $offset, $group );
 		} else {
 			$id = $this->_key( $key, $group );
 			$result = $this->_call_redis( 'incrBy', $id, $offset );
@@ -950,11 +950,8 @@ class WP_Object_Cache {
 					$val = $val + $offset;
 					return $val;
 				case 'hIncrBy':
-					if ( isset( $this->cache[ $arguments[0] ][ $arguments[1] ] ) ) {
-						return $this->cache[ $arguments[0] ][ $arguments[1] ] + $arguments[2];
-					} else {
-						return $arguments[2];
-					}
+					$val = $this->_get_internal( $arguments[1], $arguments[3] );
+					return $val + $arguments[2];
 				case 'decrBy':
 				case 'decr':
 					$val = $this->cache[ $arguments[0] ];

--- a/object-cache.php
+++ b/object-cache.php
@@ -693,7 +693,7 @@ class WP_Object_Cache {
 			if ( isset( $this->cache[ $group ][ $key ] ) || array_key_exists( $key, $this->cache[ $group ] ) ) {
 				return true;
 			} else {
-				return $this->_call_redis( 'hexists', $group, $key );
+				return $this->_call_redis( 'hExists', $group, $key );
 			}
 		} else {
 			$id = $this->_key( $key, $group );

--- a/object-cache.php
+++ b/object-cache.php
@@ -904,6 +904,12 @@ class WP_Object_Cache {
 					$offset = isset( $arguments[1] ) && 'incrBy' === $method ? $arguments[1] : 1;
 					$val = $val + $offset;
 					return $val;
+				case 'hIncrBy':
+					if ( isset( $this->cache[ $arguments[0] ][ $arguments[1] ] ) ) {
+						return $this->cache[ $arguments[0] ][ $arguments[1] ] + $arguments[2];
+					} else {
+						return $arguments[2];
+					}
 				case 'decrBy':
 				case 'decr':
 					$val = $this->cache[ $arguments[0] ];

--- a/readme.txt
+++ b/readme.txt
@@ -33,7 +33,8 @@ This assumes you have a PHP environment with the [required PhpRedis extension](h
 
 3. Engage thrusters: you are now backing WP's Object Cache with Redis.
 4. (Optional) To use the same Redis server with multiple, discreet WordPress installs, you can use the `WP_CACHE_KEY_SALT` constant to define a unique salt for each install.
-5. (Optional) On an existing site previously using WordPress' transient cache, use WP-CLI to delete all (`%_transient_%`) transients from the options table: `wp transient delete-all`. WP Redis assumes responsibility for the transient cache.
+5. (Optional) To use true cache groups, with the ability to delete all keys for a given group, define the `WP_REDIS_USE_CACHE_GROUPS` constant to true. However, when enabled, the expiration value is not respected because expiration on group keys isn't a feature supported by Redis.
+6. (Optional) On an existing site previously using WordPress' transient cache, use WP-CLI to delete all (`%_transient_%`) transients from the options table: `wp transient delete-all`. WP Redis assumes responsibility for the transient cache.
 
 == Frequently Asked Questions ==
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,6 +13,10 @@ if ( getenv( 'WP_CORE_DIR' ) ) {
 	$_core_dir = '/tmp/wordpress';
 }
 
+if ( getenv( 'WP_REDIS_USE_CACHE_GROUPS' ) ) {
+	define( 'WP_REDIS_USE_CACHE_GROUPS', true );
+}
+
 // Easiest way to get this to where WordPress will load it
 copy( dirname( dirname( __FILE__ ) ) . '/object-cache.php', $_core_dir . '/wp-content/object-cache.php' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,3 +21,10 @@ if ( getenv( 'WP_REDIS_USE_CACHE_GROUPS' ) ) {
 copy( dirname( dirname( __FILE__ ) ) . '/object-cache.php', $_core_dir . '/wp-content/object-cache.php' );
 
 require $_tests_dir . '/includes/bootstrap.php';
+
+error_log( PHP_EOL );
+$phpredis_state = class_exists( 'Redis' ) ? 'enabled' : 'disabled';
+error_log( 'PhpRedis: ' . $phpredis_state . PHP_EOL );
+$cache_groups_state = defined( 'WP_REDIS_USE_CACHE_GROUPS' ) && WP_REDIS_USE_CACHE_GROUPS ? 'enabled' : 'disabled';
+error_log( 'Cache groups: ' . $cache_groups_state . PHP_EOL );
+error_log( PHP_EOL );

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -373,7 +373,12 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertFalse( $this->cache->get( $key2, $group ) );
 		$this->assertEquals( $val3, $this->cache->get( $key3, $group2 ) );
 
-		$this->assertFalse( $this->cache->delete_group( $group ) );
+		// _call_redis( 'delete' ) always returns true when Redis isn't available
+		if ( class_exists( 'PHPRedis' ) ) {
+			$this->assertFalse( $this->cache->delete_group( $group ) );
+		} else {
+			$this->assertTrue( $this->cache->delete_group( $group ) );
+		}
 	}
 
 	function test_delete_group_non_persistent() {

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -412,6 +412,41 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertFalse( $this->cache->delete_group( $group ) );
 	}
 
+	function test_wp_cache_delete_group() {
+		if ( ! defined( 'WP_REDIS_USE_CACHE_GROUPS' ) || ! WP_REDIS_USE_CACHE_GROUPS ) {
+			$this->markTestSkipped( 'Cache groups not enabled.' );
+		}
+		$key1 = rand_str();
+		$val1 = rand_str();
+		$key2 = rand_str();
+		$val2 = rand_str();
+		$key3 = rand_str();
+		$val3 = rand_str();
+		$group = 'foo';
+		$group2 = 'bar';
+
+		// Set up the values
+		wp_cache_set( $key1, $val1, $group );
+		wp_cache_set( $key2, $val2, $group );
+		wp_cache_set( $key3, $val3, $group2 );
+		$this->assertEquals( $val1, wp_cache_get( $key1, $group ) );
+		$this->assertEquals( $val2, wp_cache_get( $key2, $group ) );
+		$this->assertEquals( $val3, wp_cache_get( $key3, $group2 ) );
+
+		$this->assertTrue( wp_cache_delete_group( $group ) );
+
+		$this->assertFalse( wp_cache_get( $key1, $group ) );
+		$this->assertFalse( wp_cache_get( $key2, $group ) );
+		$this->assertEquals( $val3, wp_cache_get( $key3, $group2 ) );
+
+		// _call_redis( 'delete' ) always returns true when Redis isn't available
+		if ( class_exists( 'Redis' ) ) {
+			$this->assertFalse( wp_cache_delete_group( $group ) );
+		} else {
+			$this->assertTrue( wp_cache_delete_group( $group ) );
+		}
+	}
+
 	function test_switch_to_blog() {
 		if ( ! method_exists( $this->cache, 'switch_to_blog' ) )
 			return;

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -226,6 +226,20 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertEquals( 3, $this->cache->get( $key ) );
 	}
 
+	function test_incr_non_persistent() {
+		$key = rand_str();
+
+		$this->cache->add_non_persistent_groups( array( 'nonpersistent' ) );
+		$this->assertFalse( $this->cache->incr( $key, 1, 'nonpersistent' ) );
+
+		$this->cache->set( $key, 0, 'nonpersistent' );
+		$this->cache->incr( $key, 1, 'nonpersistent' );
+		$this->assertEquals( 1, $this->cache->get( $key, 'nonpersistent' ) );
+
+		$this->cache->incr( $key, 2, 'nonpersistent' );
+		$this->assertEquals( 3, $this->cache->get( $key, 'nonpersistent' ) );
+	}
+
 	function test_wp_cache_incr() {
 		$key = rand_str();
 
@@ -254,6 +268,24 @@ class CacheTest extends WP_UnitTestCase {
 
 		$this->cache->decr( $key, 2 );
 		$this->assertEquals( 0, $this->cache->get( $key ) );
+	}
+
+	function test_decr_non_persistent() {
+		$key = rand_str();
+
+		$this->cache->add_non_persistent_groups( array( 'nonpersistent' ) );
+		$this->assertFalse( $this->cache->decr( $key, 1, 'nonpersistent' ) );
+
+		$this->cache->set( $key, 0, 'nonpersistent' );
+		$this->cache->decr( $key, 1, 'nonpersistent' );
+		$this->assertEquals( 0, $this->cache->get( $key, 'nonpersistent' ) );
+
+		$this->cache->set( $key, 3, 'nonpersistent' );
+		$this->cache->decr( $key, 1, 'nonpersistent' );
+		$this->assertEquals( 2, $this->cache->get( $key, 'nonpersistent' ) );
+
+		$this->cache->decr( $key, 2, 'nonpersistent' );
+		$this->assertEquals( 0, $this->cache->get( $key, 'nonpersistent' ) );
 	}
 
 	/**

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -274,6 +274,14 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertEquals( 0, $this->cache->get( $key ) );
 	}
 
+	function test_decr_never_below_zero() {
+		$key = rand_str();
+		$this->cache->set( $key, 1 );
+		$this->assertEquals( 1, $this->cache->get( $key ) );
+		$this->cache->decr( $key, 2 );
+		$this->assertEquals( 0, $this->cache->get( $key ) );
+	}
+
 	function test_decr_non_persistent() {
 		$key = rand_str();
 
@@ -288,6 +296,15 @@ class CacheTest extends WP_UnitTestCase {
 		$this->cache->decr( $key, 1, 'nonpersistent' );
 		$this->assertEquals( 2, $this->cache->get( $key, 'nonpersistent' ) );
 
+		$this->cache->decr( $key, 2, 'nonpersistent' );
+		$this->assertEquals( 0, $this->cache->get( $key, 'nonpersistent' ) );
+	}
+
+	function test_decr_non_persistent_never_below_zero() {
+		$key = rand_str();
+		$this->cache->add_non_persistent_groups( array( 'nonpersistent' ) );
+		$this->cache->set( $key, 1, 'nonpersistent' );
+		$this->assertEquals( 1, $this->cache->get( $key, 'nonpersistent' ) );
 		$this->cache->decr( $key, 2, 'nonpersistent' );
 		$this->assertEquals( 0, $this->cache->get( $key, 'nonpersistent' ) );
 	}

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -9,6 +9,10 @@ class CacheTest extends WP_UnitTestCase {
 
 	function setUp() {
 		parent::setUp();
+		$GLOBALS['redis_server'] = array(
+			'host'    => '127.0.0.1',
+			'port'    => 6379,
+		);
 		// create two cache objects with a shared cache dir
 		// this simulates a typical cache situation, two separate requests interacting
 		$this->cache =& $this->init_cache();

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -374,7 +374,7 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertEquals( $val3, $this->cache->get( $key3, $group2 ) );
 
 		// _call_redis( 'delete' ) always returns true when Redis isn't available
-		if ( class_exists( 'PHPRedis' ) ) {
+		if ( class_exists( 'Redis' ) ) {
 			$this->assertFalse( $this->cache->delete_group( $group ) );
 		} else {
 			$this->assertTrue( $this->cache->delete_group( $group ) );

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -230,6 +230,14 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertEquals( 3, $this->cache->get( $key ) );
 	}
 
+	function test_incr_never_below_zero() {
+		$key = rand_str();
+		$this->cache->set( $key, 1 );
+		$this->assertEquals( 1, $this->cache->get( $key ) );
+		$this->cache->incr( $key, -2 );
+		$this->assertEquals( 0, $this->cache->get( $key ) );
+	}
+
 	function test_incr_non_persistent() {
 		$key = rand_str();
 
@@ -242,6 +250,15 @@ class CacheTest extends WP_UnitTestCase {
 
 		$this->cache->incr( $key, 2, 'nonpersistent' );
 		$this->assertEquals( 3, $this->cache->get( $key, 'nonpersistent' ) );
+	}
+
+	function test_incr_non_persistent_never_below_zero() {
+		$key = rand_str();
+		$this->cache->add_non_persistent_groups( array( 'nonpersistent' ) );
+		$this->cache->set( $key, 1, 'nonpersistent' );
+		$this->assertEquals( 1, $this->cache->get( $key, 'nonpersistent' ) );
+		$this->cache->incr( $key, -2, 'nonpersistent' );
+		$this->assertEquals( 0, $this->cache->get( $key, 'nonpersistent' ) );
 	}
 
 	function test_wp_cache_incr() {

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -342,6 +342,67 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertFalse( wp_cache_delete( $key, 'default') );
 	}
 
+	function test_delete_group() {
+		if ( ! defined( 'WP_REDIS_USE_CACHE_GROUPS' ) || ! WP_REDIS_USE_CACHE_GROUPS ) {
+			$this->markTestSkipped( 'Cache groups not enabled.' );
+		}
+		$key1 = rand_str();
+		$val1 = rand_str();
+		$key2 = rand_str();
+		$val2 = rand_str();
+		$key3 = rand_str();
+		$val3 = rand_str();
+		$group = 'foo';
+		$group2 = 'bar';
+
+		// Set up the values
+		$this->cache->set( $key1, $val1, $group );
+		$this->cache->set( $key2, $val2, $group );
+		$this->cache->set( $key3, $val3, $group2 );
+		$this->assertEquals( $val1, $this->cache->get( $key1, $group ) );
+		$this->assertEquals( $val2, $this->cache->get( $key2, $group ) );
+		$this->assertEquals( $val3, $this->cache->get( $key3, $group2 ) );
+
+		$this->assertTrue( $this->cache->delete_group( $group ) );
+
+		$this->assertFalse( $this->cache->get( $key1, $group ) );
+		$this->assertFalse( $this->cache->get( $key2, $group ) );
+		$this->assertEquals( $val3, $this->cache->get( $key3, $group2 ) );
+
+		$this->assertFalse( $this->cache->delete_group( $group ) );
+	}
+
+	function test_delete_group_non_persistent() {
+		if ( ! defined( 'WP_REDIS_USE_CACHE_GROUPS' ) || ! WP_REDIS_USE_CACHE_GROUPS ) {
+			$this->markTestSkipped( 'Cache groups not enabled.' );
+		}
+		$key1 = rand_str();
+		$val1 = rand_str();
+		$key2 = rand_str();
+		$val2 = rand_str();
+		$key3 = rand_str();
+		$val3 = rand_str();
+		$group = 'foo';
+		$group2 = 'bar';
+		$this->cache->add_non_persistent_groups( array( $group, $group2 ) );
+
+		// Set up the values
+		$this->cache->set( $key1, $val1, $group );
+		$this->cache->set( $key2, $val2, $group );
+		$this->cache->set( $key3, $val3, $group2 );
+		$this->assertEquals( $val1, $this->cache->get( $key1, $group ) );
+		$this->assertEquals( $val2, $this->cache->get( $key2, $group ) );
+		$this->assertEquals( $val3, $this->cache->get( $key3, $group2 ) );
+
+		$this->assertTrue( $this->cache->delete_group( $group ) );
+
+		$this->assertFalse( $this->cache->get( $key1, $group ) );
+		$this->assertFalse( $this->cache->get( $key2, $group ) );
+		$this->assertEquals( $val3, $this->cache->get( $key3, $group2 ) );
+
+		$this->assertFalse( $this->cache->delete_group( $group ) );
+	}
+
 	function test_switch_to_blog() {
 		if ( ! method_exists( $this->cache, 'switch_to_blog' ) )
 			return;


### PR DESCRIPTION
For situations where it's useful to be able to clear the cache for an entire group, define `WP_REDIS_USE_CACHE_GROUPS` in your wp-config.php or similar. However, be aware the expire value can't be set in Redis on cache group keys.

Fixes #44