### PR TITLE
Run test suite against multisite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,6 @@ matrix:
     - php: 5.6
       env: WP_VERSION=latest PHP_REDIS=disabled
     - php: 5.6
-      env: WP_VERSION=latest WP_MULTISITE=1 PHP_REDIS=enabled
-    - php: 5.6
-      env: WP_VERSION=latest WP_MULTISITE=1 PHP_REDIS=disabled
-    - php: 5.6
       env: WP_VERSION=nightly PHP_REDIS=enabled
 
 services:
@@ -38,3 +34,4 @@ script:
         echo 'extension = "redis.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
       fi
       phpunit
+      phpunit -c multisite.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ matrix:
     - php: 5.6
       env: WP_VERSION=latest PHP_REDIS=disabled
     - php: 5.6
+      env: WP_VERSION=latest WP_MULTISITE=1 PHP_REDIS=enabled
+    - php: 5.6
+      env: WP_VERSION=latest WP_MULTISITE=1 PHP_REDIS=disabled
+    - php: 5.6
       env: WP_VERSION=nightly PHP_REDIS=enabled
 
 services:

--- a/multisite.xml
+++ b/multisite.xml
@@ -1,0 +1,17 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<php>
+		<const name="WP_TESTS_MULTISITE" value="1" />
+	</php>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>


### PR DESCRIPTION
Because our cache keys are influenced by the current blog, it's good to
ensure our tests also pass against multisite.