### PR TITLE
Add `wp redis-cli` to launch `redis-cli` reusing WP Redis creds

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -1,0 +1,34 @@
+<?php
+
+class WP_Redis_CLI_Command {
+
+	/**
+	 * Launch redis-cli using Redis configuration for WordPress
+	 */
+	public function __invoke() {
+		global $redis_server;
+
+		if ( empty( $redis_server ) ) {
+			# Attempt to automatically load Pantheon's Redis config from the env.
+			if ( isset( $_SERVER['CACHE_HOST'] ) ) {
+				$redis_server = array(
+					'host' => $_SERVER['CACHE_HOST'],
+					'port' => $_SERVER['CACHE_PORT'],
+					'auth' => $_SERVER['CACHE_PASSWORD'],
+				);
+			} else {
+				$redis_server = array(
+					'host' => '127.0.0.1',
+					'port' => 6379,
+				);
+			}
+		}
+
+		$cmd = WP_CLI\Utils\esc_cmd( 'redis-cli -h %s -p %s -a %s', $redis_server['host'], $redis_server['port'], $redis_server['auth'] );
+		WP_CLI::launch( $cmd );
+
+	}
+
+}
+
+WP_CLI::add_command( 'redis-cli', 'WP_Redis_CLI_Command' );

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -1,12 +1,12 @@
 <?php
-/*
-	Plugin Name: WP Redis
-	Plugin URI: http://github.com/pantheon-systems/wp-redis/
-	Description: WordPress Object Cache using Redis. Requires the PhpRedis extension (https://github.com/phpredis/phpredis).
-	Version: 0.3.0
-	Author: Pantheon, Josh Koenig, Matthew Boynes, Daniel Bachhuber Alley Interactive
-	Author URI: https://pantheon.io/
-*/
+/**
+ * Plugin Name: WP Redis
+ * Plugin URI: http://github.com/pantheon-systems/wp-redis/
+ * Description: WordPress Object Cache using Redis. Requires the PhpRedis extension (https://github.com/phpredis/phpredis).
+ * Version: 0.3.0
+ * Author: Pantheon, Josh Koenig, Matthew Boynes, Daniel Bachhuber Alley Interactive
+ * Author URI: https://pantheon.io/
+ */
 /*  This program is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
 	the Free Software Foundation; either version 2 of the License, or

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -21,3 +21,7 @@
 	along with this program; if not, write to the Free Software
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
+
+if ( defined( 'WP_CLI' ) && WP_CLI && ! class_exists( 'WP_Redis_CLI_Command' ) ) {
+	require_once dirname( __FILE__ ) . '/cli.php';
+}


### PR DESCRIPTION
Command is added when the plugin is activated, or can be used with `wp --require=cli.php`

Fixes #45