### PR TITLE
For consistency, call `del` instead of `delete`

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -488,7 +488,7 @@ class WP_Object_Cache {
 				$result = $this->_call_redis( 'hDel', $redis_safe_group, $key );
 			} else {
 				$id = $this->_key( $key, $group );
-				$result = $this->_call_redis( 'delete', $id );
+				$result = $this->_call_redis( 'del', $id );
 			}
 			if ( 1 !== $result ) {
 				return false;
@@ -513,7 +513,7 @@ class WP_Object_Cache {
 		$multisite_safe_group = $this->multisite && ! isset( $this->global_groups[ $group ] ) ? $this->blog_prefix . $group : $group;
 		$redis_safe_group = $this->_key( '', $group );
 		if ( $this->_should_persist( $group ) ) {
-			$result = $this->_call_redis( 'delete', $redis_safe_group );
+			$result = $this->_call_redis( 'del', $redis_safe_group );
 			if ( 1 !== $result ) {
 				return false;
 			}
@@ -1066,7 +1066,7 @@ class WP_Object_Cache {
 				$offset = isset( $arguments[1] ) && 'decrBy' === $method ? $arguments[1] : 1;
 				$val = $val - $offset;
 				return $val;
-			case 'delete':
+			case 'del':
 			case 'hDel':
 				return 1;
 			case 'flushAll':

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -34,7 +34,7 @@ class CacheTest extends WP_UnitTestCase {
 		self::$incrBy_key = WP_Object_Cache::USE_GROUPS ? 'hIncrBy' : 'incrBy';
 		// 'hIncrBy' isn't a typo here — Redis doesn't support decrBy on groups
 		self::$decrBy_key = WP_Object_Cache::USE_GROUPS ? 'hIncrBy' : 'decrBy';
-		self::$delete_key = WP_Object_Cache::USE_GROUPS ? 'hDel' : 'delete';
+		self::$delete_key = WP_Object_Cache::USE_GROUPS ? 'hDel' : 'del';
 
 	}
 


### PR DESCRIPTION
`delete` is a wrapper PHPredis provides. `del` is the actual Redis call.