### PR TITLE
Remove `exists` call from cache get

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -1092,6 +1092,8 @@ class WP_Object_Cache {
 			case 'flushAll':
 			case 'IsConnected':
 			case 'exists':
+			case 'get':
+			case 'hGet':
 				return false;
 		}
 

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -151,7 +151,7 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertEquals( 1, $this->cache->cache_misses );
 		if ( $this->cache->is_redis_connected ) {
 			$this->assertEquals( array(
-				self::$exists_key     => 1,
+				self::$get_key     => 1,
 			), $this->cache->redis_calls );
 		} else {
 			$this->assertEmpty( $this->cache->redis_calls );
@@ -251,8 +251,9 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertEquals( $val2, $this->cache->get( $key ) );
 		if ( $this->cache->is_redis_connected ) {
 			$this->assertEquals( array(
-				self::$exists_key     => 3,
+				self::$exists_key     => 2,
 				self::$set_key        => 2,
+				self::$get_key        => 1,
 			), $this->cache->redis_calls );
 		} else {
 			$this->assertEmpty( $this->cache->redis_calls );
@@ -361,7 +362,7 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertEquals( 2, $this->cache->cache_misses );
 		if ( $this->cache->is_redis_connected ) {
 			$this->assertEquals( array(
-				self::$exists_key        => 2,
+				self::$get_key        => 2,
 			), $this->cache->redis_calls );
 		} else {
 			$this->assertEmpty( $this->cache->redis_calls );
@@ -651,9 +652,10 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertFalse( $this->cache->delete( $key, 'default' ) );
 		if ( $this->cache->is_redis_connected ) {
 			$this->assertEquals( array(
-				self::$exists_key     => 2,
+				self::$exists_key     => 1,
 				self::$set_key        => 1,
 				self::$delete_key     => 1,
+				self::$get_key        => 1,
 			), $this->cache->redis_calls );
 		} else {
 			$this->assertEmpty( $this->cache->redis_calls );

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -407,7 +407,6 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertEquals( 0, $this->cache->cache_misses );
 		if ( $this->cache->is_redis_connected ) {
 			$this->assertEquals( array(
-				self::$exists_key        => 1,
 				self::$get_key           => 1,
 			), $this->cache->redis_calls );
 		} else {
@@ -430,7 +429,6 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertEquals( 0, $this->cache->cache_misses );
 		if ( $this->cache->is_redis_connected ) {
 			$this->assertEquals( array(
-				self::$exists_key        => 1,
 				self::$get_key           => 1,
 			), $this->cache->redis_calls );
 		} else {
@@ -454,7 +452,6 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertEquals( 0, $this->cache->cache_misses );
 		if ( $this->cache->is_redis_connected ) {
 			$this->assertEquals( array(
-				self::$exists_key        => 1,
 				self::$get_key           => 1,
 			), $this->cache->redis_calls );
 		} else {


### PR DESCRIPTION
Because PhpRedis returns `false` when the cache key doesn't exist, we
don't need to make an `exists` call beforehand

See #85