### PR TITLE
Set type to wordpress-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "pantheon-systems/wp-redis",
+  "type": "wordpress-plugin",
   "authors": [
     {
       "name": "Pantheon",


### PR DESCRIPTION
This allows us to include it in our composer.json.