### PR TITLE
Permit unauthenticated builds to run successfully on Circle

### DIFF
--- a/bin/behat-cleanup.sh
+++ b/bin/behat-cleanup.sh
@@ -6,6 +6,11 @@
 
 set -ex
 
+if [ -z "$TERMINUS_TOKEN" ]; then
+	echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
+	exit 0
+fi
+
 if [ -z "$TERMINUS_SITE" ] || [ -z "$TERMINUS_ENV" ]; then
 	echo "TERMINUS_SITE and TERMINUS_ENV environment variables must be set"
 	exit 1

--- a/bin/behat-cleanup.sh
+++ b/bin/behat-cleanup.sh
@@ -4,12 +4,12 @@
 # Delete the Pantheon site environment after the Behat test suite has run.
 ###
 
-set -ex
-
 if [ -z "$TERMINUS_TOKEN" ]; then
 	echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
 	exit 0
 fi
+
+set -ex
 
 if [ -z "$TERMINUS_SITE" ] || [ -z "$TERMINUS_ENV" ]; then
 	echo "TERMINUS_SITE and TERMINUS_ENV environment variables must be set"

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -8,6 +8,11 @@
 
 set -ex
 
+if [ -z "$TERMINUS_TOKEN" ]; then
+	echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
+	exit 0
+fi
+
 if [ -z "$TERMINUS_SITE" ] || [ -z "$TERMINUS_ENV" ]; then
 	echo "TERMINUS_SITE and TERMINUS_ENV environment variables must be set"
 	exit 1

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -6,12 +6,12 @@
 # such that it can be run a second time if a step fails.
 ###
 
-set -ex
-
 if [ -z "$TERMINUS_TOKEN" ]; then
 	echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
 	exit 0
 fi
+
+set -ex
 
 if [ -z "$TERMINUS_SITE" ] || [ -z "$TERMINUS_ENV" ]; then
 	echo "TERMINUS_SITE and TERMINUS_ENV environment variables must be set"

--- a/bin/behat-test.sh
+++ b/bin/behat-test.sh
@@ -6,6 +6,11 @@
 
 set -ex
 
+if [ -z "$TERMINUS_TOKEN" ]; then
+	echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
+	exit 0
+fi
+
 export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "http://'$TERMINUS_ENV'-'$TERMINUS_SITE'.pantheonsite.io"} }}'
 
 ./vendor/bin/behat

--- a/bin/behat-test.sh
+++ b/bin/behat-test.sh
@@ -4,12 +4,12 @@
 # Execute the Behat test suite against a prepared Pantheon site environment.
 ###
 
-set -ex
-
 if [ -z "$TERMINUS_TOKEN" ]; then
 	echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
 	exit 0
 fi
+
+set -ex
 
 export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "http://'$TERMINUS_ENV'-'$TERMINUS_SITE'.pantheonsite.io"} }}'
 

--- a/circle.yml
+++ b/circle.yml
@@ -16,9 +16,14 @@ dependencies:
     # xdebug makes composer slower.
     - echo "date.timezone = 'US/Central'"  >  /opt/circleci/php/5.6.22/etc/conf.d/xdebug.ini    
   override:
-    - composer global require pantheon-systems/terminus
-    - composer install
-    - terminus auth login --machine-token=$TERMINUS_TOKEN
+    - |
+      if [ -z "$TERMINUS_TOKEN" ]; then
+        echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
+        exit 0
+      fi
+      composer global require pantheon-systems/terminus
+      composer install
+      terminus auth login --machine-token=$TERMINUS_TOKEN
 
 test:
   pre:


### PR DESCRIPTION
When non-organization users submit pull requests, we don't want the build to fail.

After merging, the build will run on the master branch, where we can learn whether there are any integration failures on Pantheon.