### PR TITLE
Remove overly specific requirement from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,8 @@
   "require-dev": {
     "squizlabs/php_codesniffer": "2.3.4",
     "wp-coding-standards/wpcs": "0.9.0",
-    "behat/mink-selenium2-driver": "~1.1",
-    "behat/mink-extension": "~2.0",
-    "symfony/dependency-injection": "2.7.11",
     "behat/behat": "^3.1",
+    "behat/mink-extension": "^2.2",
     "behat/mink-goutte-driver": "^1.2",
     "pantheon-systems/pantheon-wordpress-upstream-tests": "dev-master"
   },


### PR DESCRIPTION
I suspect that some of the items in `require-dev` are overly specific and not needed. I'm going to use this PR to find out how many can be removed. I think `"behat/behat": "^3.1",` may be all that is needed to trigger the downloading of the other Behat-related items.


