### PR TITLE
Symlink object-cache.php on activation #126

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,18 @@ Go forth and make awesome! And, once you've built something great, [send us feat
 
 This assumes you have a PHP environment with the [required PhpRedis extension](https://github.com/phpredis/phpredis) and a working Redis server (e.g. Pantheon).
 
-1. Install `object-cache.php` to `wp-content/object-cache.php` with a symlink or by copying the file.
-2. If you're not running on Pantheon, edit wp-config.php to add your cache credentials, e.g.:
+#### Automatic Symlinking
+
+- Install / Activate the plugin, and it'll attempt creating a symlink to `wp-content/object-cache.php` automatically.
+
+#### Manual way
+
+- Install `object-cache.php` to `wp-content/object-cache.php` with a symlink or by copying the file.
+
+
+#### Optional Configuration
+
+- If you're not running on Pantheon, edit wp-config.php to add your cache credentials, e.g.:
 
         $redis_server = array(
             'host'     => '127.0.0.1',
@@ -35,11 +45,12 @@ This assumes you have a PHP environment with the [required PhpRedis extension](h
             'database' => 0, // Optionally use a specific numeric Redis database. Default is 0.
         );
 
-3. Engage thrusters: you are now backing WP's Object Cache with Redis.
-4. (Optional) To use the `wp redis` WP-CLI commands, activate the WP Redis plugin. No activation is necessary if you're solely using the object cache drop-in.
-5. (Optional) To use the same Redis server with multiple, discreet WordPress installs, you can use the `WP_CACHE_KEY_SALT` constant to define a unique salt for each install.
-6. (Optional) To use true cache groups, with the ability to delete all keys for a given group, register groups with `wp_cache_add_redis_hash_groups()`, or define the `WP_REDIS_USE_CACHE_GROUPS` constant to true to enable with all groups. However, when enabled, the expiration value is not respected because expiration on group keys isn't a feature supported by Redis.
-7. (Optional) On an existing site previously using WordPress' transient cache, use WP-CLI to delete all (`%_transient_%`) transients from the options table: `wp transient delete-all`. WP Redis assumes responsibility for the transient cache.
+- To use the `wp redis` WP-CLI commands, activate the WP Redis plugin. No activation is necessary if you're solely using the object cache drop-in.
+- To use the same Redis server with multiple, discreet WordPress installs, you can use the `WP_CACHE_KEY_SALT` constant to define a unique salt for each install.
+- To use true cache groups, with the ability to delete all keys for a given group, register groups with `wp_cache_add_redis_hash_groups()`, or define the `WP_REDIS_USE_CACHE_GROUPS` constant to true to enable with all groups. However, when enabled, the expiration value is not respected because expiration on group keys isn't a feature supported by Redis.
+- (Optional) On an existing site previously using WordPress' transient cache, use WP-CLI to delete all (`%_transient_%`) transients from the options table: `wp transient delete-all`. WP Redis assumes responsibility for the transient cache.
+
+Engage thrusters! you are now backing WordPress's Object Cache with Redis!
 
 ## Contributing ##
 
@@ -69,6 +80,10 @@ If you are concerned with the speed of your site, backing it with a high-perform
 ### How does this work with other caching plugins? ###
 
 This plugin is for the internal application object cache. It doesn't have anything to do with page caches. On Pantheon you do not need additional page caching, but if you are self-hosted you can use your favorite page cache plugins in conjunction with WP Redis.
+
+### Can I disable automatic creation of the symlink ? ###
+
+You can define `WP_REDIS_NO_SYMLINK` to stop the plugin from automatically creating/removing the symlink on plugin activation/deactivation. ie: `define( 'WP_REDIS_NO_SYMLINK', true )`
 
 ### How do I disable the persistent object cache for a bad actor? ###
 

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -47,7 +47,6 @@ rm -rf $PREPARE_DIR/wp-content/object-cache.php
 cd $BASH_DIR/..
 rsync -av --exclude='vendor/' --exclude='node_modules/' --exclude='tests/' ./* $PREPARE_DIR/wp-content/plugins/wp-redis
 rm -rf $PREPARE_DIR/wp-content/plugins/wp-redis/.git
-cp object-cache.php $PREPARE_DIR/wp-content/object-cache.php
 
 ###
 # Add the debugging plugin to the environment

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -140,6 +140,8 @@ function symlink_status() {
 	}
 }
 
-register_activation_hook( __FILE__, __NAMESPACE__ . '\\activation' );
-register_deactivation_hook( __FILE__, __NAMESPACE__ . '\\deactivation' );
-add_action( 'admin_notices', __NAMESPACE__ . '\\admin_check' );
+if ( ! defined( 'WP_REDIS_NO_SYMLINK' ) ) {
+	register_activation_hook( __FILE__, __NAMESPACE__ . '\\activation' );
+	register_deactivation_hook( __FILE__, __NAMESPACE__ . '\\deactivation' );
+	add_action( 'admin_notices', __NAMESPACE__ . '\\admin_check' );
+}

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -89,7 +89,7 @@ function admin_check() {
 	if ( ! defined( 'WP_REDIS_OBJECT_CACHE' ) && ! file_exists( WP_CONTENT_DIR . '/object-cache.php' ) ) {
 
 		$error = sprintf(
-		/* translators: %s: path to object-cache.php file */
+			/* translators: %s: path to object-cache.php file */
 			esc_html__( 'No file/symlink was found at %s. Please deactivate and reactivate wp-redis plugin to install the required drop-in.', 'wp-redis' ),
 			'<code>' . esc_html( WP_CONTENT_DIR . '/object-cache.php' ) . '</code>'
 		);
@@ -124,7 +124,7 @@ function symlink_status() {
 
 		return -1;
 
-	} elseif ( $src === readlink( $dest ) ) {
+	} elseif ( readlink( $dest ) === $src ) {
 
 		return true;
 

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -22,6 +22,119 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+namespace WPRedis;
+
 if ( defined( 'WP_CLI' ) && WP_CLI && ! class_exists( 'WP_Redis_CLI_Command' ) ) {
 	require_once dirname( __FILE__ ) . '/cli.php';
 }
+
+/**
+ * On activation: Check symlink status on plugin activation, disable the plugin if the file exists already
+ * and is not symlinked properly
+ */
+function activation() {
+
+	if ( file_exists( $db = WP_CONTENT_DIR . '/object-cache.php' ) ) {
+
+		$status = symlink_status();
+
+		if ( false === $status ) {
+
+			$error = sprintf(
+				/* translators: %s: path to object-cache.php file */
+				esc_html__( 'The symlink at %s is no longer pointing to the correct location. Please remove the symlink, then reactivate wp-redis plugin.', 'wp-redis' ),
+				'<code>' . esc_html( WP_CONTENT_DIR . '/object-cache.php' ) . '</code>'
+			);
+
+			deactivate_plugins( __FILE__ );
+			wp_die( $error );
+
+		} elseif ( -1 === $status ) {
+
+			$error = sprintf(
+				/* translators: %s: path to object-cache.php file */
+				esc_html__( 'The file at %s is not a symlink. Please remove the file, then reactivate wp-redis plugin again to create the symlink.', 'wp-redis' ),
+				'<code>' . esc_html( WP_CONTENT_DIR . '/object-cache.php' ) . '</code>'
+			);
+
+			deactivate_plugins( __FILE__ );
+			wp_die( $error );
+
+		}
+	} else {
+
+		if ( function_exists( 'symlink' ) ) {
+			@symlink( plugin_dir_path( __FILE__ ) . 'object-cache.php', $db );
+		}
+	}
+}
+
+/**
+ * On deactivation: remove the symlinked file if found and is pointing to the correct file
+ */
+function deactivation() {
+
+	if ( true === symlink_status() ) {
+		unlink( WP_CONTENT_DIR . '/object-cache.php' );
+	}
+}
+
+/**
+ * Check if the object-cache file is symlinked correctly, warn if not
+ *
+ * @action admin_notices
+ */
+function admin_check() {
+
+	if ( ! defined( 'WP_REDIS_OBJECT_CACHE' ) && ! file_exists( WP_CONTENT_DIR . '/object-cache.php' ) ) {
+
+		$error = sprintf(
+		/* translators: %s: path to object-cache.php file */
+			esc_html__( 'No file/symlink was found at %s. Please deactivate and reactivate wp-redis plugin to install the required drop-in.', 'wp-redis' ),
+			'<code>' . esc_html( WP_CONTENT_DIR . '/object-cache.php' ) . '</code>'
+		);
+
+		printf( '<div class="updated error"><p>%s</p></div>', $error );
+
+	} elseif ( false === symlink_status() ) {
+
+		$error = sprintf(
+			/* translators: %s: path to object-cache.php file */
+			esc_html__( 'The symlink at %s is no longer pointing to the correct location. Please remove the symlink, then deactivate and reactivate wp-redis plugin.', 'wp-redis' ),
+			'<code>' . esc_html( WP_CONTENT_DIR . '/object-cache.php' ) . '</code>'
+		);
+
+		printf( '<div class="updated error"><p>%s</p></div>', $error );
+
+	}
+}
+
+/**
+ * Check symlink status of the object-cache.php file
+ *
+ *
+ * @return bool|int Returns -1 if the file is not symlinked, false if symlink is broken, true if linked correctly
+ */
+function symlink_status() {
+
+	$dest = WP_CONTENT_DIR . '/object-cache.php';
+	$src  = plugin_dir_path( __FILE__ ) . 'object-cache.php';
+
+	if ( ! is_link( $dest ) ) {
+
+		return -1;
+
+	} elseif ( $src === readlink( $dest ) ) {
+
+		return true;
+
+	} else {
+
+		return false;
+
+	}
+}
+
+register_activation_hook( __FILE__, __NAMESPACE__ . '\\activation' );
+register_deactivation_hook( __FILE__, __NAMESPACE__ . '\\deactivation' );
+add_action( 'admin_notices', __NAMESPACE__ . '\\admin_check' );

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -47,7 +47,7 @@ function activation() {
 			);
 
 			deactivate_plugins( __FILE__ );
-			wp_die( $error );
+			wp_die( wp_kses( $error, array( 'code' => array() ) ) );
 
 		} elseif ( -1 === $status ) {
 
@@ -58,13 +58,15 @@ function activation() {
 			);
 
 			deactivate_plugins( __FILE__ );
-			wp_die( $error );
+			wp_die( wp_kses( $error, array( 'code' => array() ) ) );
 
 		}
 	} else {
 
 		if ( function_exists( 'symlink' ) ) {
+			// @codingStandardsIgnoreStart
 			@symlink( plugin_dir_path( __FILE__ ) . 'object-cache.php', $db );
+			// @codingStandardsIgnoreEnd
 		}
 	}
 }
@@ -73,10 +75,11 @@ function activation() {
  * On deactivation: remove the symlinked file if found and is pointing to the correct file
  */
 function deactivation() {
-
+	// @codingStandardsIgnoreStart
 	if ( true === symlink_status() ) {
 		unlink( WP_CONTENT_DIR . '/object-cache.php' );
 	}
+	// @codingStandardsIgnoreEnd
 }
 
 /**
@@ -88,23 +91,25 @@ function admin_check() {
 
 	if ( ! defined( 'WP_REDIS_OBJECT_CACHE' ) && ! file_exists( WP_CONTENT_DIR . '/object-cache.php' ) ) {
 
-		$error = sprintf(
-			/* translators: %s: path to object-cache.php file */
-			esc_html__( 'No file/symlink was found at %s. Please deactivate and reactivate wp-redis plugin to install the required drop-in.', 'wp-redis' ),
-			'<code>' . esc_html( WP_CONTENT_DIR . '/object-cache.php' ) . '</code>'
+		printf(
+			'<div class="updated error"><p>%s</p></div>',
+			sprintf(
+				/* translators: %s: path to object-cache.php file */
+				esc_html__( 'No file/symlink was found at %s. Please deactivate and reactivate wp-redis plugin to install the required drop-in.', 'wp-redis' ),
+				'<code>' . esc_html( WP_CONTENT_DIR . '/object-cache.php' ) . '</code>'
+			)
 		);
-
-		printf( '<div class="updated error"><p>%s</p></div>', $error );
 
 	} elseif ( false === symlink_status() ) {
 
-		$error = sprintf(
-			/* translators: %s: path to object-cache.php file */
-			esc_html__( 'The symlink at %s is no longer pointing to the correct location. Please remove the symlink, then deactivate and reactivate wp-redis plugin.', 'wp-redis' ),
-			'<code>' . esc_html( WP_CONTENT_DIR . '/object-cache.php' ) . '</code>'
+		printf(
+			'<div class="updated error"><p>%s</p></div>',
+			sprintf(
+				/* translators: %s: path to object-cache.php file */
+				esc_html__( 'The symlink at %s is no longer pointing to the correct location. Please remove the symlink, then deactivate and reactivate wp-redis plugin.', 'wp-redis' ),
+				'<code>' . esc_html( WP_CONTENT_DIR . '/object-cache.php' ) . '</code>'
+			)
 		);
-
-		printf( '<div class="updated error"><p>%s</p></div>', $error );
 
 	}
 }


### PR DESCRIPTION
Resolves #126 

This adds routines to:

- Symlink `object-cache.php` file on activation, with proper checks if the file exists, if symlinked (properly).
- Remove the symlink on deactivation in case it is pointing to the plugins directory.
- Display notice about improper symlink and/or missing file as an admin notice

And I've took the liberty of removing the `cp` command in Behat script so we can test if it worked properly. Might need some more tests to cover the few new scenarios, but I'm not entirely sure how I can do that with the current structure.