### PR TITLE
Permit setup scripts to be run locally without `TERMINUS_TOKEN` set

### DIFF
--- a/bin/behat-cleanup.sh
+++ b/bin/behat-cleanup.sh
@@ -4,9 +4,9 @@
 # Delete the Pantheon site environment after the Behat test suite has run.
 ###
 
-terminus auth whoami
+terminus auth whoami > /dev/null
 if [ $? -ne 0 ]; then
-	echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
+	echo "Terminus unauthenticated; assuming unauthenticated build"
 	exit 0
 fi
 

--- a/bin/behat-cleanup.sh
+++ b/bin/behat-cleanup.sh
@@ -4,7 +4,8 @@
 # Delete the Pantheon site environment after the Behat test suite has run.
 ###
 
-if [ -z "$TERMINUS_TOKEN" ]; then
+terminus auth whoami
+if [ $? -ne 0 ]; then
 	echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
 	exit 0
 fi

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -6,9 +6,9 @@
 # such that it can be run a second time if a step fails.
 ###
 
-terminus auth whoami
+terminus auth whoami > /dev/null
 if [ $? -ne 0 ]; then
-	echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
+	echo "Terminus unauthenticated; assuming unauthenticated build"
 	exit 0
 fi
 

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -6,7 +6,8 @@
 # such that it can be run a second time if a step fails.
 ###
 
-if [ -z "$TERMINUS_TOKEN" ]; then
+terminus auth whoami
+if [ $? -ne 0 ]; then
 	echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
 	exit 0
 fi

--- a/bin/behat-test.sh
+++ b/bin/behat-test.sh
@@ -4,9 +4,9 @@
 # Execute the Behat test suite against a prepared Pantheon site environment.
 ###
 
-terminus auth whoami
+terminus auth whoami > /dev/null
 if [ $? -ne 0 ]; then
-	echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
+	echo "Terminus unauthenticated; assuming unauthenticated build"
 	exit 0
 fi
 

--- a/bin/behat-test.sh
+++ b/bin/behat-test.sh
@@ -4,7 +4,8 @@
 # Execute the Behat test suite against a prepared Pantheon site environment.
 ###
 
-if [ -z "$TERMINUS_TOKEN" ]; then
+terminus auth whoami
+if [ $? -ne 0 ]; then
 	echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
 	exit 0
 fi


### PR DESCRIPTION
This conditional check is functionally equivalent