### PR TITLE
Introduce `wp redis info` for basic Redis connection details

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -80,10 +80,11 @@ class WP_Redis_CLI_Command {
 	 *     | status         | connected |
 	 *     | used_memory    | 529.38K   |
 	 *     | uptime         | 0 days    |
+	 *     | key_count      | 11        |
 	 *     | redis_host     | 127.0.0.1 |
 	 *     | redis_port     | 6379      |
 	 *     | redis_auth     |           |
-	 *     | redis_database |           |
+	 *     | redis_database | 0         |
 	 *     +----------------+-----------+
 	 *
 	 *     $ wp redis info --field=used_memory
@@ -104,14 +105,20 @@ class WP_Redis_CLI_Command {
 			} else {
 				$uptime_in_days .= ' days';
 			}
+			$database = ! empty( $redis_server['database'] ) ? $redis_server['database'] : 0;
+			$key_count = 0;
+			if ( preg_match( '#keys=([\d]+)#', $info[ 'db' . $database ], $matches ) ) {
+				$key_count = $matches[1];
+			}
 			$data = array(
 				'status'          => 'connected',
 				'used_memory'     => $info['used_memory_human'],
 				'uptime'          => $uptime_in_days,
+				'key_count'       => $key_count,
 				'redis_host'      => $redis_server['host'],
 				'redis_port'      => ! empty( $redis_server['port'] ) ? $redis_server['port'] : 6379,
 				'redis_auth'      => ! empty( $redis_server['auth'] ) ? $redis_server['auth'] : '',
-				'redis_database'  => ! empty( $redis_server['database'] ) ? $redis_server['database'] : '',
+				'redis_database'  => $database,
 			);
 			$formatter = new \WP_CLI\Formatter( $assoc_args, array_keys( $data ) );
 			$formatter->display_item( $data );

--- a/cli.php
+++ b/cli.php
@@ -93,7 +93,7 @@ class WP_Redis_CLI_Command {
 		global $wp_object_cache, $redis_server;
 
 		if ( ! defined( 'WP_REDIS_OBJECT_CACHE' ) || ! WP_REDIS_OBJECT_CACHE ) {
-			WP_CLI::error( "WP Redis object-cache.php file is missing from the wp-content/ directory." );
+			WP_CLI::error( 'WP Redis object-cache.php file is missing from the wp-content/ directory.' );
 		}
 
 		if ( $wp_object_cache->is_redis_connected ) {

--- a/cli.php
+++ b/cli.php
@@ -107,7 +107,7 @@ class WP_Redis_CLI_Command {
 
 		if ( $wp_object_cache->is_redis_connected && WP_CLI\Utils\get_flag_value( $assoc_args, 'reset' ) ) {
 			// Redis::resetStat() isn't functional, see https://github.com/phpredis/phpredis/issues/928
-			if ( $wp_object_cache->redis->eval("return redis.call('CONFIG','RESETSTAT')") ) {
+			if ( $wp_object_cache->redis->eval( "return redis.call('CONFIG','RESETSTAT')" ) ) {
 				WP_CLI::success( 'Redis stats reset.' );
 			} else {
 				WP_CLI::error( "Couldn't reset Redis stats." );

--- a/cli.php
+++ b/cli.php
@@ -74,18 +74,20 @@ class WP_Redis_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *     $ wp redis info
-	 *     +----------------+-----------+
-	 *     | Field          | Value     |
-	 *     +----------------+-----------+
-	 *     | status         | connected |
-	 *     | used_memory    | 529.38K   |
-	 *     | uptime         | 0 days    |
-	 *     | key_count      | 11        |
-	 *     | redis_host     | 127.0.0.1 |
-	 *     | redis_port     | 6379      |
-	 *     | redis_auth     |           |
-	 *     | redis_database | 0         |
-	 *     +----------------+-----------+
+	 *     +-------------------+-----------+
+	 *     | Field             | Value     |
+	 *     +-------------------+-----------+
+	 *     | status            | connected |
+	 *     | used_memory       | 529.25K   |
+	 *     | uptime            | 0 days    |
+	 *     | key_count         | 20        |
+	 *     | instantaneous_ops | 9/sec     |
+	 *     | lifetime_hitrate  | 53.42%    |
+	 *     | redis_host        | 127.0.0.1 |
+	 *     | redis_port        | 6379      |
+	 *     | redis_auth        |           |
+	 *     | redis_database    | 0         |
+	 *     +-------------------+-----------+
 	 *
 	 *     $ wp redis info --field=used_memory
 	 *     529.38K
@@ -111,14 +113,16 @@ class WP_Redis_CLI_Command {
 				$key_count = $matches[1];
 			}
 			$data = array(
-				'status'          => 'connected',
-				'used_memory'     => $info['used_memory_human'],
-				'uptime'          => $uptime_in_days,
-				'key_count'       => $key_count,
-				'redis_host'      => $redis_server['host'],
-				'redis_port'      => ! empty( $redis_server['port'] ) ? $redis_server['port'] : 6379,
-				'redis_auth'      => ! empty( $redis_server['auth'] ) ? $redis_server['auth'] : '',
-				'redis_database'  => $database,
+				'status'            => 'connected',
+				'used_memory'       => $info['used_memory_human'],
+				'uptime'            => $uptime_in_days,
+				'key_count'         => $key_count,
+				'instantaneous_ops' => $info['instantaneous_ops_per_sec'] . '/sec',
+				'lifetime_hitrate'  => round( ( $info['keyspace_hits'] / ( $info['keyspace_hits'] + $info['keyspace_misses'] ) * 100 ), 2 ) . '%',
+				'redis_host'        => $redis_server['host'],
+				'redis_port'        => ! empty( $redis_server['port'] ) ? $redis_server['port'] : 6379,
+				'redis_auth'        => ! empty( $redis_server['auth'] ) ? $redis_server['auth'] : '',
+				'redis_database'    => $database,
 			);
 			$formatter = new \WP_CLI\Formatter( $assoc_args, array_keys( $data ) );
 			$formatter->display_item( $data );

--- a/cli.php
+++ b/cli.php
@@ -112,37 +112,14 @@ class WP_Redis_CLI_Command {
 			} else {
 				WP_CLI::error( "Couldn't reset Redis stats." );
 			}
-		} else if ( $wp_object_cache->is_redis_connected ) {
-			$info = $wp_object_cache->redis->info();
-			$uptime_in_days = $info['uptime_in_days'];
-			if ( 1 === $info['uptime_in_days'] ) {
-				$uptime_in_days .= ' day';
-			} else {
-				$uptime_in_days .= ' days';
+		} else {
+			$data = wp_redis_get_info();
+			if ( is_wp_error( $data ) ) {
+				WP_CLI::error( $data );
 			}
-			$database = ! empty( $redis_server['database'] ) ? $redis_server['database'] : 0;
-			$key_count = 0;
-			if ( preg_match( '#keys=([\d]+)#', $info[ 'db' . $database ], $matches ) ) {
-				$key_count = $matches[1];
-			}
-			$data = array(
-				'status'            => 'connected',
-				'used_memory'       => $info['used_memory_human'],
-				'uptime'            => $uptime_in_days,
-				'key_count'         => $key_count,
-				'instantaneous_ops' => $info['instantaneous_ops_per_sec'] . '/sec',
-				'lifetime_hitrate'  => round( ( $info['keyspace_hits'] / ( $info['keyspace_hits'] + $info['keyspace_misses'] ) * 100 ), 2 ) . '%',
-				'redis_host'        => $redis_server['host'],
-				'redis_port'        => ! empty( $redis_server['port'] ) ? $redis_server['port'] : 6379,
-				'redis_auth'        => ! empty( $redis_server['auth'] ) ? $redis_server['auth'] : '',
-				'redis_database'    => $database,
-			);
 			$formatter = new \WP_CLI\Formatter( $assoc_args, array_keys( $data ) );
 			$formatter->display_item( $data );
-		} else {
-			WP_CLI::error( $wp_object_cache->missing_redis_message );
 		}
-
 	}
 
 	/**

--- a/cli.php
+++ b/cli.php
@@ -106,6 +106,7 @@ class WP_Redis_CLI_Command {
 		}
 
 		if ( $wp_object_cache->is_redis_connected && WP_CLI\Utils\get_flag_value( $assoc_args, 'reset' ) ) {
+			// Redis::resetStat() isn't functional, see https://github.com/phpredis/phpredis/issues/928
 			if ( $wp_object_cache->redis->eval("return redis.call('CONFIG','RESETSTAT')") ) {
 				WP_CLI::success( 'Redis stats reset.' );
 			} else {

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -22,6 +22,11 @@ if ( getenv( 'WP_REDIS_USE_CACHE_GROUPS' ) ) {
 // Easiest way to get this to where WordPress will load it
 copy( dirname( dirname( dirname( __FILE__ ) ) ) . '/object-cache.php', $_core_dir . '/wp-content/object-cache.php' );
 
+function _manually_load_plugin() {
+	require dirname( dirname( dirname( __FILE__ ) ) ) . '/wp-redis.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
 require $_tests_dir . '/includes/bootstrap.php';
 
 error_log( PHP_EOL );

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -926,6 +926,17 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertFalse( wp_cache_get( $fake_key ) );
 	}
 
+	public function test_wp_redis_get_info() {
+		if ( ! class_exists( 'Redis' ) ) {
+			$this->markTestSkipped( 'PHPRedis extension not available.' );
+		}
+		$data = wp_redis_get_info();
+		$this->assertEquals( 'connected', $data['status'] );
+		$this->assertInternalType( 'int', $data['key_count'] );
+		$this->assertRegExp( '/[\d]+\/sec/', $data['instantaneous_ops'] );
+		$this->assertRegExp( '/[\d]+\sdays/', $data['uptime'] );
+	}
+
 	public function tearDown() {
 		parent::tearDown();
 		$this->flush_cache();

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -25,3 +25,45 @@
 if ( defined( 'WP_CLI' ) && WP_CLI && ! class_exists( 'WP_Redis_CLI_Command' ) ) {
 	require_once dirname( __FILE__ ) . '/cli.php';
 }
+
+/**
+ * Get helpful details on the Redis connection. Used by the WP-CLI command.
+ *
+ * @return array
+ */
+function wp_redis_get_info() {
+	global $wp_object_cache, $redis_server;
+
+	if ( ! defined( 'WP_REDIS_OBJECT_CACHE' ) || ! WP_REDIS_OBJECT_CACHE ) {
+		return new WP_Error( 'wp-redis', 'WP Redis object-cache.php file is missing from the wp-content/ directory.' );
+	}
+
+	if ( ! $wp_object_cache->is_redis_connected ) {
+		return new WP_Error( 'wp-redis', $wp_object_cache->missing_redis_message );
+	}
+
+	$info = $wp_object_cache->redis->info();
+	$uptime_in_days = $info['uptime_in_days'];
+	if ( 1 === $info['uptime_in_days'] ) {
+		$uptime_in_days .= ' day';
+	} else {
+		$uptime_in_days .= ' days';
+	}
+	$database = ! empty( $redis_server['database'] ) ? $redis_server['database'] : 0;
+	$key_count = 0;
+	if ( isset( $info[ 'db' . $database ] ) && preg_match( '#keys=([\d]+)#', $info[ 'db' . $database ], $matches ) ) {
+		$key_count = $matches[1];
+	}
+	return array(
+		'status'            => 'connected',
+		'used_memory'       => $info['used_memory_human'],
+		'uptime'            => $uptime_in_days,
+		'key_count'         => $key_count,
+		'instantaneous_ops' => $info['instantaneous_ops_per_sec'] . '/sec',
+		'lifetime_hitrate'  => round( ( $info['keyspace_hits'] / ( $info['keyspace_hits'] + $info['keyspace_misses'] ) * 100 ), 2 ) . '%',
+		'redis_host'        => $redis_server['host'],
+		'redis_port'        => ! empty( $redis_server['port'] ) ? $redis_server['port'] : 6379,
+		'redis_auth'        => ! empty( $redis_server['auth'] ) ? $redis_server['auth'] : '',
+		'redis_database'    => $database,
+	);
+}


### PR DESCRIPTION
```
salty-wordpress ➜  wp-redis  wp redis info
+-------------------+-----------+
| Field             | Value     |
+-------------------+-----------+
| status            | connected |
| used_memory       | 531.16K   |
| uptime            | 0 days    |
| key_count         | 21        |
| instantaneous_ops | 9/sec     |
| lifetime_hitrate  | 60%       |
| redis_host        | 127.0.0.1 |
| redis_port        | 6379      |
| redis_auth        |           |
| redis_database    | 0         |
+-------------------+-----------+
```

See #117