### PR TITLE
Introduce `wp_cache_add_redis_hash_groups()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This assumes you have a PHP environment with the [required PhpRedis extension](h
 3. Engage thrusters: you are now backing WP's Object Cache with Redis.
 4. (Optional) To use the `wp redis` WP-CLI commands, activate the WP Redis plugin. No activation is necessary if you're solely using the object cache drop-in.
 5. (Optional) To use the same Redis server with multiple, discreet WordPress installs, you can use the `WP_CACHE_KEY_SALT` constant to define a unique salt for each install.
-6. (Optional) To use true cache groups, with the ability to delete all keys for a given group, define the `WP_REDIS_USE_CACHE_GROUPS` constant to true. However, when enabled, the expiration value is not respected because expiration on group keys isn't a feature supported by Redis.
+6. (Optional) To use true cache groups, with the ability to delete all keys for a given group, register groups with `wp_cache_add_redis_hash_groups()`, or define the `WP_REDIS_USE_CACHE_GROUPS` constant to true to enable with all groups. However, when enabled, the expiration value is not respected because expiration on group keys isn't a feature supported by Redis.
 7. (Optional) On an existing site previously using WordPress' transient cache, use WP-CLI to delete all (`%_transient_%`) transients from the options table: `wp transient delete-all`. WP Redis assumes responsibility for the transient cache.
 
 ## Contributing ##

--- a/readme.txt
+++ b/readme.txt
@@ -37,7 +37,7 @@ This assumes you have a PHP environment with the [required PhpRedis extension](h
 3. Engage thrusters: you are now backing WP's Object Cache with Redis.
 4. (Optional) To use the `wp redis` WP-CLI commands, activate the WP Redis plugin. No activation is necessary if you're solely using the object cache drop-in.
 5. (Optional) To use the same Redis server with multiple, discreet WordPress installs, you can use the `WP_CACHE_KEY_SALT` constant to define a unique salt for each install.
-6. (Optional) To use true cache groups, with the ability to delete all keys for a given group, define the `WP_REDIS_USE_CACHE_GROUPS` constant to true. However, when enabled, the expiration value is not respected because expiration on group keys isn't a feature supported by Redis.
+6. (Optional) To use true cache groups, with the ability to delete all keys for a given group, register groups with `wp_cache_add_redis_hash_groups()`, or define the `WP_REDIS_USE_CACHE_GROUPS` constant to true to enable with all groups. However, when enabled, the expiration value is not respected because expiration on group keys isn't a feature supported by Redis.
 7. (Optional) On an existing site previously using WordPress' transient cache, use WP-CLI to delete all (`%_transient_%`) transients from the options table: `wp transient delete-all`. WP Redis assumes responsibility for the transient cache.
 
 == Contributing ==

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -749,9 +749,6 @@ class CacheTest extends WP_UnitTestCase {
 	}
 
 	public function test_delete_group() {
-		if ( ! defined( 'WP_REDIS_USE_CACHE_GROUPS' ) || ! WP_REDIS_USE_CACHE_GROUPS ) {
-			$this->markTestSkipped( 'Cache groups not enabled.' );
-		}
 		$key1 = rand_str();
 		$val1 = rand_str();
 		$key2 = rand_str();
@@ -760,6 +757,10 @@ class CacheTest extends WP_UnitTestCase {
 		$val3 = rand_str();
 		$group = 'foo';
 		$group2 = 'bar';
+
+		if ( ! defined( 'WP_REDIS_USE_CACHE_GROUPS' ) || ! WP_REDIS_USE_CACHE_GROUPS ) {
+			$this->cache->add_redis_hash_groups( array( $group, $group2 ) );
+		}
 
 		// Set up the values
 		$this->cache->set( $key1, $val1, $group );
@@ -784,9 +785,6 @@ class CacheTest extends WP_UnitTestCase {
 	}
 
 	public function test_delete_group_non_persistent() {
-		if ( ! defined( 'WP_REDIS_USE_CACHE_GROUPS' ) || ! WP_REDIS_USE_CACHE_GROUPS ) {
-			$this->markTestSkipped( 'Cache groups not enabled.' );
-		}
 		$key1 = rand_str();
 		$val1 = rand_str();
 		$key2 = rand_str();
@@ -796,6 +794,10 @@ class CacheTest extends WP_UnitTestCase {
 		$group = 'foo';
 		$group2 = 'bar';
 		$this->cache->add_non_persistent_groups( array( $group, $group2 ) );
+
+		if ( ! defined( 'WP_REDIS_USE_CACHE_GROUPS' ) || ! WP_REDIS_USE_CACHE_GROUPS ) {
+			$this->cache->add_redis_hash_groups( array( $group, $group2 ) );
+		}
 
 		// Set up the values
 		$this->cache->set( $key1, $val1, $group );
@@ -815,9 +817,7 @@ class CacheTest extends WP_UnitTestCase {
 	}
 
 	public function test_wp_cache_delete_group() {
-		if ( ! defined( 'WP_REDIS_USE_CACHE_GROUPS' ) || ! WP_REDIS_USE_CACHE_GROUPS ) {
-			$this->markTestSkipped( 'Cache groups not enabled.' );
-		}
+
 		$key1 = rand_str();
 		$val1 = rand_str();
 		$key2 = rand_str();
@@ -826,6 +826,10 @@ class CacheTest extends WP_UnitTestCase {
 		$val3 = rand_str();
 		$group = 'foo';
 		$group2 = 'bar';
+
+		if ( ! defined( 'WP_REDIS_USE_CACHE_GROUPS' ) || ! WP_REDIS_USE_CACHE_GROUPS ) {
+			$GLOBALS['wp_object_cache']->add_redis_hash_groups( array( $group, $group2 ) );
+		}
 
 		// Set up the values
 		wp_cache_set( $key1, $val1, $group );


### PR DESCRIPTION
This function permits registering specific groups to use Redis hashes,
and is more precise than our existing `WP_REDIS_USE_CACHE_GROUPS` constant.

Fixes #113