### PR TITLE
Use a better unauthenticated check

### DIFF
--- a/bin/behat-cleanup.sh
+++ b/bin/behat-cleanup.sh
@@ -4,8 +4,9 @@
 # Delete the Pantheon site environment after the Behat test suite has run.
 ###
 
-if [ -z "$TERMINUS_TOKEN" ]; then
-	echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
+terminus auth whoami > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Terminus unauthenticated; assuming unauthenticated build"
 	exit 0
 fi
 

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -6,8 +6,9 @@
 # such that it can be run a second time if a step fails.
 ###
 
-if [ -z "$TERMINUS_TOKEN" ]; then
-	echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
+terminus auth whoami > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Terminus unauthenticated; assuming unauthenticated build"
 	exit 0
 fi
 

--- a/bin/behat-test.sh
+++ b/bin/behat-test.sh
@@ -4,8 +4,9 @@
 # Execute the Behat test suite against a prepared Pantheon site environment.
 ###
 
-if [ -z "$TERMINUS_TOKEN" ]; then
-	echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
+terminus auth whoami > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Terminus unauthenticated; assuming unauthenticated build"
 	exit 0
 fi
 

--- a/bin/behat-test.sh
+++ b/bin/behat-test.sh
@@ -10,6 +10,11 @@ if [ $? -ne 0 ]; then
 	exit 0
 fi
 
+if [ -z "$TERMINUS_SITE" ] || [ -z "$TERMINUS_ENV" ]; then
+	echo "TERMINUS_SITE and TERMINUS_ENV environment variables must be set"
+	exit 1
+fi
+
 if [ -z "$WORDPRESS_ADMIN_USERNAME" ] || [ -z "$WORDPRESS_ADMIN_PASSWORD" ]; then
 	echo "WORDPRESS_ADMIN_USERNAME and WORDPRESS_ADMIN_PASSWORD environment variables must be set"
 	exit 1


### PR DESCRIPTION
This way, the script can be run when `terminus` is already
authenticated, but `TERMINUS_TOKEN` isn't present