### PR TITLE
Terminus Version number

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,7 +28,7 @@ dependencies:
         echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
         exit 0
       fi
-      composer global require pantheon-systems/terminus
+      composer global require pantheon-systems/terminus "<0.13.0"
       composer install
       terminus auth login --machine-token=$TERMINUS_TOKEN
 


### PR DESCRIPTION
Going back to an older version of Terminus to get tests passing again in master. Follow up issue here: https://github.com/pantheon-systems/wp-redis/issues/146