### PR TITLE
Fix race condition with alloptions

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -937,6 +937,16 @@ class WP_Object_Cache {
 	}
 
 	/**
+	 * Clear internal cache for alloptions. Avoids race conditions when
+	 * updating options in the alloptions concurrently.
+	 *
+	 * @param string $option
+	 */
+	public function _unset_internal_alloptions( $option ) {
+		$this->_unset_internal( 'alloptions', 'options' );
+	}
+
+	/**
 	 * Utility function to generate the redis key for a given key and group.
 	 *
 	 * @param  string $key   The cache key.
@@ -1181,6 +1191,10 @@ class WP_Object_Cache {
 
 		$this->multisite = is_multisite();
 		$this->blog_prefix = $this->multisite ? $blog_id . ':' : '';
+
+		add_action( 'update_option', array( $this, '_unset_internal_alloptions' ), 10, 1 );
+		add_action( 'add_option', array( $this, '_unset_internal_alloptions' ), 10, 1 );
+		add_action( 'delete_option', array( $this, '_unset_internal_alloptions' ), 10, 1 );
 
 		if ( ! $this->_connect_redis() && function_exists( 'add_action' ) ) {
 			add_action( 'admin_notices', array( $this, 'wp_action_admin_notices_warn_missing_redis' ) );


### PR DESCRIPTION
Steps to reproduce the bug:

1. Open wp shell in terminal A
2. Write a new option `my` with `update_option('my', 'first');`
3. Open wp shell in terminal B
4. Update the option value in terminal A with `update_option('my', 'second');`
5. Write any new option in terminal B: `update_option('anythingnew', 'something');`
6. Close wp shell in terminal A and reopen it
7. Read the value in terminal A with `get_option('my')` and you'll get `first` instead of `second`

This can also happen with http requests in Wordpress but it's much harder
to reproduce. It can certainly happen even though it's rare but that's
why this is really nasty. You can think of the wp shells as long running
http requests.

The bug occurs because WP reads the `alloptions` option at the start up
(wp shell or http request) which causes it to be cached the internal
wp-redis PHP memory cache.  When the shell is opened in terminal B it
gets the value for the `my` option from step 2 (cached in the
`alloptions`!).  In the step 4 the value is updated but the shell in
terminal B keeps the previous value because it is in the internal cache.
When the shell in terminal B writes some other value it will use the
old version of the `alloptions` option to write the value which causes
the value of the `my` option to be written too - with the old value.

This commit ensures that the `alloptions` is always read fresh from
Redis when Wordpress core or plugin code updates any options. Whether it
is a new option, modifying existing one or deleting an option.
Performance impact should be miminal because the cache is busted only on
writes.

These changes were made with help of @MikkoVirenius