### PR TITLE
Empty password confuses redis-cli

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -28,7 +28,7 @@ class WP_Redis_CLI_Command {
 			$redis_server['database'] = 0;
 		}
 
-		$cmd = WP_CLI\Utils\esc_cmd( 'redis-cli -h %s -p %s -a %s -n %d', $redis_server['host'], $redis_server['port'], $redis_server['auth'], $redis_server['database'] );
+		$cmd = WP_CLI\Utils\esc_cmd( 'redis-cli -h "%s" -p "%s" -a "%s" -n "%d"', $redis_server['host'], $redis_server['port'], $redis_server['auth'], $redis_server['database'] );
 		WP_CLI::launch( $cmd );
 
 	}


### PR DESCRIPTION
Arguments should be quoted.