### PR TITLE
Update hook in tests for external clients

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 
 language: php
 
@@ -35,6 +36,7 @@ matrix:
       env: WP_TRAVISCI=phpcs
     - php: 5.3
       env: WP_VERSION=latest PHP_REDIS=enabled
+      dist: precise
 
 services:
     - redis-server

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -144,7 +144,7 @@ class CacheTest extends WP_UnitTestCase {
 		$redis_server['host'] = '127.0.0.1';
 		$redis_server['port'] = 9999;
 		$client_parameters = $this->cache->build_client_parameters( $redis_server );
-		$client_connection = apply_filters( 'wp_redis_client_connection_callback', array( $this->cache, 'prepare_client_connection' ) );
+		$client_connection = apply_filters( 'wp_redis_prepare_client_connection_callback', array( $this->cache, 'prepare_client_connection' ) );
 		$this->cache->redis = call_user_func_array( $client_connection, array( $client_parameters ) );
 		// Setting cache value when redis connection fails saves wakeup flush
 		$this->cache->set( 'foo', 'bar' );


### PR DESCRIPTION
I've got failing tests over in [`wp-redis-predis-client`](https://github.com/humanmade/wp-redis-predis-client) and I realize I didn't name one of the hooks correctly. This fixes that!