### PR TITLE
Use `flushdb` instead of `flushAll`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 
 ## Changelog ##
 
+### 0.8.0 (Unreleased) ###
+* Uses `flushdb` instead of `flushAll` to avoid flushing the entire Redis instance [[#259](https://github.com/pantheon-systems/wp-redis/pull/259)].
+
 ### 0.7.1 (December 14, 2018) ###
 * Better support in `wp_cache_init()` for drop-ins like LudicrousDB [[#231](https://github.com/pantheon-systems/wp-redis/pull/231)].
 * Cleans up PHPCS issues.

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -79,8 +79,8 @@ install_test_suite() {
 	if [ ! -d $WP_TESTS_DIR ]; then
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+		svn co --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
 
 	if [ ! -f wp-tests-config.php ]; then

--- a/object-cache.php
+++ b/object-cache.php
@@ -574,7 +574,7 @@ class WP_Object_Cache {
 	public function flush( $redis = true ) {
 		$this->cache = array();
 		if ( $redis ) {
-			$this->_call_redis( 'flushAll' );
+			$this->_call_redis( 'flushdb' );
 		}
 
 		return true;

--- a/readme.txt
+++ b/readme.txt
@@ -107,6 +107,9 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 
 == Changelog ==
 
+= 0.8.0 (Unreleased) =
+* Uses `flushdb` instead of `flushAll` to avoid flushing the entire Redis instance [[#259](https://github.com/pantheon-systems/wp-redis/pull/259)].
+
 = 0.7.1 (December 14, 2018) =
 * Better support in `wp_cache_init()` for drop-ins like LudicrousDB [[#231](https://github.com/pantheon-systems/wp-redis/pull/231)].
 * Cleans up PHPCS issues.

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -48,7 +48,7 @@ class CacheTest extends WP_UnitTestCase {
 		// 'hIncrBy' isn't a typo here — Redis doesn't support decrBy on groups
 		self::$decr_by_key   = WP_Object_Cache::USE_GROUPS ? 'hIncrBy' : 'decrBy';
 		self::$delete_key    = WP_Object_Cache::USE_GROUPS ? 'hDel' : 'del';
-		self::$flush_all_key = 'flushAll';
+		self::$flush_all_key = 'flushdb';
 
 	}
 
@@ -1262,6 +1262,7 @@ class CacheTest extends WP_UnitTestCase {
 		}
 		$redis_server['database'] = 2;
 		$second_cache             = new WP_Object_Cache;
+		$second_cache->flush(); // Make sure it's in pristine state.
 		$this->cache->set( 'foo', 'bar' );
 		$this->assertEquals( 'bar', $this->cache->get( 'foo' ) );
 		$this->assertFalse( $second_cache->get( 'foo' ) );

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Redis
  * Plugin URI: http://github.com/pantheon-systems/wp-redis/
  * Description: WordPress Object Cache using Redis. Requires the PhpRedis extension (https://github.com/phpredis/phpredis).
- * Version: 0.7.1
+ * Version: 0.8.0-alpha
  * Author: Pantheon, Josh Koenig, Matthew Boynes, Daniel Bachhuber, Alley Interactive
  * Author URI: https://pantheon.io/
  */


### PR DESCRIPTION
`flushAll` flushes all Redis database instances. We only want to flush
the database WordPress is connected to.

Fixes #258 