### PR TITLE
Fix `wp redis cli` by using `proc_open()` directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** cache, plugin, redis  
 **Requires at least:** 3.0.1  
 **Tested up to:** 5.3  
-**Stable tag:** 0.8.2  
+**Stable tag:** 0.8.3  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -106,6 +106,9 @@ This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `
 There's a known issue with WordPress `alloptions` cache design. Specifically, a race condition between two requests can cause the object cache to have stale values. If you think you might be impacted by this, [review this GitHub issue](https://github.com/pantheon-systems/wp-redis/issues/221) for links to more context, including a workaround.
 
 ## Changelog ##
+
+### 0.8.3 (February 24, 2020) ###
+* Fixes `wp redis cli` by using `proc_open()` directly, instead of `WP_CLI::launch()` [[#268](https://github.com/pantheon-systems/wp-redis/pull/268)].
 
 ### 0.8.2 (January 15, 2020) ###
 * Catches exceptions when trying to connect to Redis [[#265](https://github.com/pantheon-systems/wp-redis/pull/265)].

--- a/cli.php
+++ b/cli.php
@@ -23,6 +23,7 @@ class WP_Redis_CLI_Command {
 				$redis_server = array(
 					'host' => '127.0.0.1',
 					'port' => 6379,
+					'auth' => '',
 				);
 			}
 		}
@@ -31,9 +32,10 @@ class WP_Redis_CLI_Command {
 			$redis_server['database'] = 0;
 		}
 
-		$cmd = WP_CLI\Utils\esc_cmd( 'redis-cli -h "%s" -p "%s" -a "%s" -n "%d"', $redis_server['host'], $redis_server['port'], $redis_server['auth'], $redis_server['database'] );
-		WP_CLI::launch( $cmd );
-
+		$cmd     = WP_CLI\Utils\esc_cmd( 'redis-cli -h %s -p %s -a %s -n %s', $redis_server['host'], $redis_server['port'], $redis_server['auth'], $redis_server['database'] );
+		$process = WP_CLI\Utils\proc_open_compat( $cmd, array( STDIN, STDOUT, STDERR ), $pipes );
+		$r       = proc_close( $process );
+		exit( $r );
 	}
 
 	/**

--- a/cli.php
+++ b/cli.php
@@ -35,7 +35,7 @@ class WP_Redis_CLI_Command {
 		$cmd     = WP_CLI\Utils\esc_cmd( 'redis-cli -h %s -p %s -a %s -n %s', $redis_server['host'], $redis_server['port'], $redis_server['auth'], $redis_server['database'] );
 		$process = WP_CLI\Utils\proc_open_compat( $cmd, array( STDIN, STDOUT, STDERR ), $pipes );
 		$r       = proc_close( $process );
-		exit( $r );
+		exit( (int) $r );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon, danielbachhuber, mboynes, Outlandish Josh
 Tags: cache, plugin, redis
 Requires at least: 3.0.1
 Tested up to: 5.3
-Stable tag: 0.8.2
+Stable tag: 0.8.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -106,6 +106,9 @@ This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `
 There's a known issue with WordPress `alloptions` cache design. Specifically, a race condition between two requests can cause the object cache to have stale values. If you think you might be impacted by this, [review this GitHub issue](https://github.com/pantheon-systems/wp-redis/issues/221) for links to more context, including a workaround.
 
 == Changelog ==
+
+= 0.8.3 (February 24, 2020) =
+* Fixes `wp redis cli` by using `proc_open()` directly, instead of `WP_CLI::launch()` [[#268](https://github.com/pantheon-systems/wp-redis/pull/268)].
 
 = 0.8.2 (January 15, 2020) =
 * Catches exceptions when trying to connect to Redis [[#265](https://github.com/pantheon-systems/wp-redis/pull/265)].

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Redis
  * Plugin URI: http://github.com/pantheon-systems/wp-redis/
  * Description: WordPress Object Cache using Redis. Requires the PhpRedis extension (https://github.com/phpredis/phpredis).
- * Version: 0.8.2
+ * Version: 0.8.3
  * Author: Pantheon, Josh Koenig, Matthew Boynes, Daniel Bachhuber, Alley Interactive
  * Author URI: https://pantheon.io/
  */


### PR DESCRIPTION
See https://wordpress.org/support/topic/wp-redis-cli-hangs/