### PR TITLE
Implement `wp_cache_get_multiple()` for WP 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 **Contributors:** getpantheon, danielbachhuber, mboynes, Outlandish Josh  
 **Tags:** cache, plugin, redis  
 **Requires at least:** 3.0.1  
-**Tested up to:** 5.4  
-**Stable tag:** 1.0.1  
+**Tested up to:** 5.5  
+**Stable tag:** 1.1.0  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -106,6 +106,10 @@ This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `
 There's a known issue with WordPress `alloptions` cache design. Specifically, a race condition between two requests can cause the object cache to have stale values. If you think you might be impacted by this, [review this GitHub issue](https://github.com/pantheon-systems/wp-redis/issues/221) for links to more context, including a workaround.
 
 ## Changelog ##
+
+### 1.1.0 (July 13, 2020) ###
+* Implements `wp_cache_get_multiple()` for WordPress 5.5 [[#287](https://github.com/pantheon-systems/wp-redis/pull/287)].
+* Bails early when connecting to Redis throws an Exception to avoid fatal error [[285](https://github.com/pantheon-systems/wp-redis/pull/285)].
 
 ### 1.0.1 (April 14, 2020) ###
 * Adds support for specifying Redis database number from environment/server variables [[#273](https://github.com/pantheon-systems/wp-redis/pull/273)].

--- a/object-cache.php
+++ b/object-cache.php
@@ -134,6 +134,24 @@ function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
 }
 
 /**
+ * Retrieves multiple values from the cache in one call.
+ *
+ * @see WP_Object_Cache::get_multiple()
+ * @global WP_Object_Cache $wp_object_cache Object cache global instance.
+ *
+ * @param array  $keys  Array of keys under which the cache contents are stored.
+ * @param string $group Optional. Where the cache contents are grouped. Default empty.
+ * @param bool   $force Optional. Whether to force an update of the local cache
+ *                      from the persistent cache. Default false.
+ * @return array Array of values organized into groups.
+ */
+function wp_cache_get_multiple( $keys, $group = '', $force = false ) {
+	global $wp_object_cache;
+
+	return $wp_object_cache->get_multiple( $keys, $group, $force );
+}
+
+/**
  * Increment numeric cache item's value
  *
  * @uses $wp_object_cache Object Cache Class
@@ -642,6 +660,74 @@ class WP_Object_Cache {
 		$this->cache_hits += 1;
 		$found             = true;
 		return $value;
+	}
+
+	/**
+	 * Retrieves multiple values from the cache in one call.
+	 *
+	 * @param array  $keys  Array of keys under which the cache contents are stored.
+	 * @param string $group Optional. Where the cache contents are grouped. Default empty.
+	 * @param bool   $force Optional. Whether to force an update of the local cache
+	 *                      from the persistent cache. Default false.
+	 * @return array Array of values organized into groups.
+	 */
+	public function get_multiple( $keys, $group = 'default', $force = false ) {
+		if ( empty( $group ) ) {
+			$group = 'default';
+		}
+
+		$cache = array();
+		if ( ! $this->_should_persist( $group ) ) {
+			foreach ( $keys as $key ) {
+				$cache[ $key ] = $this->_isset_internal( $key, $group ) ? $this->_get_internal( $key, $group ) : false;
+				false !== $cache[ $key ] ? $this->cache_hits++ : $this->cache_misses++;
+			}
+			return $cache;
+		}
+
+		// Attempt to fetch values from the internal cache.
+		if ( ! $force ) {
+			foreach ( $keys as $key ) {
+				if ( $this->_isset_internal( $key, $group ) ) {
+					$cache[ $key ] = $this->_get_internal( $key, $group );
+					$this->cache_hits++;
+				}
+			}
+		}
+		$remaining_keys = array_diff( $keys, array_keys( $cache ) );
+		// If all keys were satisfied by the internal cache, we're sorted.
+		if ( empty( $remaining_keys ) ) {
+			return $cache;
+		}
+		if ( $this->_should_use_redis_hashes( $group ) ) {
+			$redis_safe_group = $this->_key( '', $group );
+			$results          = $this->_call_redis( 'hmGet', $redis_safe_group, $remaining_keys );
+		} else {
+			$ids = array();
+			foreach ( $remaining_keys as $key ) {
+				$ids[] = $this->_key( $key, $group );
+			}
+			$results = $this->_call_redis( 'mget', $ids );
+		}
+		// Process the results from the Redis call.
+		foreach ( $remaining_keys as $i => $key ) {
+			$value = isset( $results[ $i ] ) ? $results[ $i ] : false;
+			if ( false !== $value ) {
+				// All non-numeric values are serialized
+				$value = is_numeric( $value ) ? intval( $value ) : unserialize( $value );
+				$this->_set_internal( $key, $group, $value );
+				$this->cache_hits++;
+			} else {
+				$this->cache_misses++;
+			}
+			$cache[ $key ] = $value;
+		}
+		// Make sure return values are returned in the order of the passed keys.
+		$return_cache = array();
+		foreach ( $keys as $key ) {
+			$return_cache[ $key ] = isset( $cache[ $key ] ) ? $cache[ $key ] : false;
+		}
+		return $return_cache;
 	}
 
 	/**
@@ -1239,7 +1325,9 @@ class WP_Object_Cache {
 			case 'IsConnected':
 			case 'exists':
 			case 'get':
+			case 'mget':
 			case 'hGet':
+			case 'hmGet':
 				return false;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: getpantheon, danielbachhuber, mboynes, Outlandish Josh
 Tags: cache, plugin, redis
 Requires at least: 3.0.1
-Tested up to: 5.4
-Stable tag: 1.0.1
+Tested up to: 5.5
+Stable tag: 1.1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -106,6 +106,10 @@ This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `
 There's a known issue with WordPress `alloptions` cache design. Specifically, a race condition between two requests can cause the object cache to have stale values. If you think you might be impacted by this, [review this GitHub issue](https://github.com/pantheon-systems/wp-redis/issues/221) for links to more context, including a workaround.
 
 == Changelog ==
+
+= 1.1.0 (July 13, 2020) =
+* Implements `wp_cache_get_multiple()` for WordPress 5.5 [[#287](https://github.com/pantheon-systems/wp-redis/pull/287)].
+* Bails early when connecting to Redis throws an Exception to avoid fatal error [[285](https://github.com/pantheon-systems/wp-redis/pull/285)].
 
 = 1.0.1 (April 14, 2020) =
 * Adds support for specifying Redis database number from environment/server variables [[#273](https://github.com/pantheon-systems/wp-redis/pull/273)].

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Redis
  * Plugin URI: http://github.com/pantheon-systems/wp-redis/
  * Description: WordPress Object Cache using Redis. Requires the PhpRedis extension (https://github.com/phpredis/phpredis).
- * Version: 1.0.1
+ * Version: 1.1.0
  * Author: Pantheon, Josh Koenig, Matthew Boynes, Daniel Bachhuber, Alley Interactive
  * Author URI: https://pantheon.io/
  */


### PR DESCRIPTION
Fixes #281