### PR TITLE
Return cache data in correct order when using `wp_cache_get_multiple()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** cache, plugin, redis  
 **Requires at least:** 3.0.1  
 **Tested up to:** 5.5  
-**Stable tag:** 1.1.0  
+**Stable tag:** 1.1.1  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -106,6 +106,9 @@ This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `
 There's a known issue with WordPress `alloptions` cache design. Specifically, a race condition between two requests can cause the object cache to have stale values. If you think you might be impacted by this, [review this GitHub issue](https://github.com/pantheon-systems/wp-redis/issues/221) for links to more context, including a workaround.
 
 ## Changelog ##
+
+### 1.1.1 (August 17, 2020) ###
+* Returns cache data in correct order when using `wp_cache_get_multiple()` and internal cache is already primed [[#292](https://github.com/pantheon-systems/wp-redis/pull/292)].
 
 ### 1.1.0 (July 13, 2020) ###
 * Implements `wp_cache_get_multiple()` for WordPress 5.5 [[#287](https://github.com/pantheon-systems/wp-redis/pull/287)].

--- a/object-cache.php
+++ b/object-cache.php
@@ -702,6 +702,7 @@ class WP_Object_Cache {
 		if ( $this->_should_use_redis_hashes( $group ) ) {
 			$redis_safe_group = $this->_key( '', $group );
 			$results          = $this->_call_redis( 'hmGet', $redis_safe_group, $remaining_keys );
+			$results          = array_values( $results );
 		} else {
 			$ids = array();
 			foreach ( $remaining_keys as $key ) {

--- a/object-cache.php
+++ b/object-cache.php
@@ -694,7 +694,7 @@ class WP_Object_Cache {
 				}
 			}
 		}
-		$remaining_keys = array_values(array_diff( $keys, array_keys( $cache ) ));
+		$remaining_keys = array_values( array_diff( $keys, array_keys( $cache ) ) );
 		// If all keys were satisfied by the internal cache, we're sorted.
 		if ( empty( $remaining_keys ) ) {
 			return $cache;

--- a/object-cache.php
+++ b/object-cache.php
@@ -694,7 +694,7 @@ class WP_Object_Cache {
 				}
 			}
 		}
-		$remaining_keys = array_diff( $keys, array_keys( $cache ) );
+		$remaining_keys = array_values(array_diff( $keys, array_keys( $cache ) ));
 		// If all keys were satisfied by the internal cache, we're sorted.
 		if ( empty( $remaining_keys ) ) {
 			return $cache;

--- a/object-cache.php
+++ b/object-cache.php
@@ -702,7 +702,7 @@ class WP_Object_Cache {
 		if ( $this->_should_use_redis_hashes( $group ) ) {
 			$redis_safe_group = $this->_key( '', $group );
 			$results          = $this->_call_redis( 'hmGet', $redis_safe_group, $remaining_keys );
-			$results          = array_values( $results );
+			$results          = is_array( $results ) ? array_values( $results ) : $results;
 		} else {
 			$ids = array();
 			foreach ( $remaining_keys as $key ) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon, danielbachhuber, mboynes, Outlandish Josh
 Tags: cache, plugin, redis
 Requires at least: 3.0.1
 Tested up to: 5.5
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -106,6 +106,9 @@ This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `
 There's a known issue with WordPress `alloptions` cache design. Specifically, a race condition between two requests can cause the object cache to have stale values. If you think you might be impacted by this, [review this GitHub issue](https://github.com/pantheon-systems/wp-redis/issues/221) for links to more context, including a workaround.
 
 == Changelog ==
+
+= 1.1.1 (August 17, 2020) =
+* Returns cache data in correct order when using `wp_cache_get_multiple()` and internal cache is already primed [[#292](https://github.com/pantheon-systems/wp-redis/pull/292)].
 
 = 1.1.0 (July 13, 2020) =
 * Implements `wp_cache_get_multiple()` for WordPress 5.5 [[#287](https://github.com/pantheon-systems/wp-redis/pull/287)].

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -789,6 +789,9 @@ class CacheTest extends WP_UnitTestCase {
 	}
 
 	public function test_get_multiple_partial_cache_miss() {
+		if ( ! class_exists( 'Redis' ) ) {
+			$this->markTestSkipped( 'Requires an active persistent object cache connection' );
+		}
 		$this->cache->set( 'foo1', 'bar', 'group1' );
 		$this->cache->set( 'foo2', 'baz', 'group1' );
 		$this->cache->set( 'foo3', 'bap', 'group1' );
@@ -809,18 +812,14 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertSame( $expected, $found );
 		$this->assertEquals( 4, $this->cache->cache_hits );
 		$this->assertEquals( 1, $this->cache->cache_misses );
-		if ( $this->cache->is_redis_connected ) {
-			$this->assertEquals(
-				array(
-					self::$get_key  => 1,
-					self::$mget_key => 1,
-					self::$set_key  => 3,
-				),
-				$this->cache->redis_calls
-			);
-		} else {
-			$this->assertEmpty( $this->cache->redis_calls );
-		}
+		$this->assertEquals(
+			array(
+				self::$get_key  => 1,
+				self::$mget_key => 1,
+				self::$set_key  => 3,
+			),
+			$this->cache->redis_calls
+		);
 	}
 
 	public function test_get_multiple_non_persistent() {

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -788,6 +788,41 @@ class CacheTest extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_get_multiple_partial_cache_miss() {
+		$this->cache->set( 'foo1', 'bar', 'group1' );
+		$this->cache->set( 'foo2', 'baz', 'group1' );
+		$this->cache->set( 'foo3', 'bap', 'group1' );
+		// Reset the internal cache.
+		$this->cache->cache = array();
+		// Prime the second item into the internal cache.
+		$this->cache->get( 'foo2', 'group1' );
+
+		$found = $this->cache->get_multiple( array( 'foo1', 'foo2', 'foo3', 'foo4' ), 'group1' );
+
+		$expected = array(
+			'foo1' => 'bar',
+			'foo2' => 'baz',
+			'foo3' => 'bap',
+			'foo4' => false,
+		);
+
+		$this->assertSame( $expected, $found );
+		$this->assertEquals( 4, $this->cache->cache_hits );
+		$this->assertEquals( 1, $this->cache->cache_misses );
+		if ( $this->cache->is_redis_connected ) {
+			$this->assertEquals(
+				array(
+					self::$get_key  => 1,
+					self::$mget_key => 1,
+					self::$set_key  => 3,
+				),
+				$this->cache->redis_calls
+			);
+		} else {
+			$this->assertEmpty( $this->cache->redis_calls );
+		}
+	}
+
 	public function test_get_multiple_non_persistent() {
 		$this->cache->add_non_persistent_groups( array( 'group1' ) );
 		$this->cache->set( 'foo1', 'bar', 'group1' );

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Redis
  * Plugin URI: http://github.com/pantheon-systems/wp-redis/
  * Description: WordPress Object Cache using Redis. Requires the PhpRedis extension (https://github.com/phpredis/phpredis).
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: Pantheon, Josh Koenig, Matthew Boynes, Daniel Bachhuber, Alley Interactive
  * Author URI: https://pantheon.io/
  */


### PR DESCRIPTION
Fixes https://github.com/pantheon-systems/wp-redis/issues/293