### PR TITLE
Support Relay via `WP_REDIS_USE_RELAY`

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -1207,7 +1207,11 @@ class WP_Object_Cache {
 	 * @return Redis Redis client.
 	 */
 	public function prepare_client_connection( $client_parameters ) {
-		$redis = new Redis;
+		if ( defined( 'WP_REDIS_USE_RELAY' ) && WP_REDIS_USE_RELAY ) {
+			$redis = new Relay\Relay;
+		} else {
+			$redis = new Redis;
+		}
 
 		$redis->connect(
 			$client_parameters['host'],


### PR DESCRIPTION
Added support for [Relay](https://relaycache.com) via `WP_REDIS_USE_RELAY` constant.

I used a constant instead of `wp_redis_prepare_client_connection_callback`, since it's a drop-in replacement for PhpRedis with an identical API.