### PR TITLE
fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 
 ## Changelog ##
 
-### Latest ###
+### 1.4.3-dev ###
+* Bug fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set. [[428](https://github.com/pantheon-systems/wp-redis/pull/428)] (props @timnolte)
 
 ### 1.4.2 (May 15, 2023) ###
 * Bug fix: Removes exception loop caused by `esc_html` in `_exception_handler()` [[421](https://github.com/pantheon-systems/wp-redis/pull/421)]

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -96,4 +96,4 @@ echo "Flush cache and setup environment..."
 terminus wp $SITE_ENV -- plugin activate wp-redis classic-editor
 terminus wp $SITE_ENV -- cache flush
 terminus wp $SITE_ENV -- theme activate twentyseventeen
-terminus wp $SITE_ENV -- rewrite structure '/%year%/%monthnum%/%day%/%postname%/'
+terminus wp $SITE_ENV -- rewrite structure '/%year%/%monthnum%/%day%/%postname%/

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -96,4 +96,4 @@ echo "Flush cache and setup environment..."
 terminus wp $SITE_ENV -- plugin activate wp-redis classic-editor
 terminus wp $SITE_ENV -- cache flush
 terminus wp $SITE_ENV -- theme activate twentyseventeen
-terminus wp $SITE_ENV -- rewrite structure '/%year%/%monthnum%/%day%/%postname%/
+terminus wp $SITE_ENV -- rewrite structure '/%year%/%monthnum%/%day%/%postname%/'

--- a/object-cache.php
+++ b/object-cache.php
@@ -1238,20 +1238,25 @@ class WP_Object_Cache {
 	 *               with defaults applied.
 	 */
 	public function build_client_parameters( $redis_server ) {
+		// Default Redis port.
+		$port = 6379;
+		// Default Redis database number.
+		$database = 0;
+
 		if ( empty( $redis_server ) ) {
 			// Attempt to automatically load Pantheon's Redis config from the env.
 			if ( isset( $_SERVER['CACHE_HOST'] ) ) {
 				$redis_server = [
 					'host' => wp_strip_all_tags( $_SERVER['CACHE_HOST'] ),
-					'port' => isset( $_SERVER['CACHE_PORT'] ) ? wp_strip_all_tags( $_SERVER['CACHE_PORT'] ) : 0,
-					'auth' => isset( $_SERVER['CACHE_PASSWORD'] ) ? wp_strip_all_tags( $_SERVER['CACHE_PASSWORD'] ) : '',
-					'database' => isset( $_SERVER['CACHE_DB'] ) ? wp_strip_all_tags( $_SERVER['CACHE_DB'] ) : 0,
+					'port' => isset( $_SERVER['CACHE_PORT'] ) ? wp_strip_all_tags( $_SERVER['CACHE_PORT'] ) : $port,
+					'auth' => isset( $_SERVER['CACHE_PASSWORD'] ) ? wp_strip_all_tags( $_SERVER['CACHE_PASSWORD'] ) : null,
+					'database' => isset( $_SERVER['CACHE_DB'] ) ? wp_strip_all_tags( $_SERVER['CACHE_DB'] ) : $database,
 				];
 			} else {
 				$redis_server = [
 					'host' => '127.0.0.1',
-					'port' => 6379,
-					'database' => 0,
+					'port' => $port,
+					'database' => $database,
 				];
 			}
 		}
@@ -1259,8 +1264,6 @@ class WP_Object_Cache {
 		if ( file_exists( $redis_server['host'] ) && 'socket' === filetype( $redis_server['host'] ) ) { // unix socket connection.
 			// port must be null or socket won't connect.
 			$port = null;
-		} else { // tcp connection.
-			$port = ! empty( $redis_server['port'] ) ? $redis_server['port'] : 6379;
 		}
 
 		$defaults = [
@@ -1470,9 +1473,9 @@ class WP_Object_Cache {
 		try {
 			$this->last_triggered_error = 'WP Redis: ' . $exception->getMessage();
 			// Be friendly to developers debugging production servers by triggering an error.
-			
+
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error,WordPress.Security.EscapeOutput.OutputNotEscaped
-			trigger_error( $this->last_triggered_error, E_USER_WARNING ); 
+			trigger_error( $this->last_triggered_error, E_USER_WARNING );
 		} catch ( PHPUnit_Framework_Error_Warning $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// PHPUnit throws an Exception when `trigger_error()` is called. To ensure our tests (which expect Exceptions to be caught) continue to run, we catch the PHPUnit exception and inspect the RedisException message.
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -102,7 +102,8 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 
 == Changelog ==
 
-= Latest =
+= 1.4.3-dev =
+* Bug fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set. [[428](https://github.com/pantheon-systems/wp-redis/pull/428)] (props @tnolte)
 
 = 1.4.2 (May 15, 2023) =
 * Bug fix: Removes exception loop caused by `esc_html` in `_exception_handler()` [[421](https://github.com/pantheon-systems/wp-redis/pull/421)]

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -38,12 +38,12 @@ function wp_redis_get_info() {
 
 	if ( empty( $redis_server ) ) {
 		// Attempt to automatically load Pantheon's Redis config from the env.
-		if ( isset( $_SERVER['CACHE_HOST'] ) && isset( $_SERVER['CACHE_PORT'] ) && isset( $_SERVER['CACHE_PASSWORD'] ) && isset( $_SERVER['CACHE_DB'] ) ) {
+		if ( isset( $_SERVER['CACHE_HOST'] ) ) {
 			$redis_server = [
 				'host' => sanitize_text_field( $_SERVER['CACHE_HOST'] ),
-				'port' => sanitize_text_field( $_SERVER['CACHE_PORT'] ),
-				'auth' => sanitize_text_field( $_SERVER['CACHE_PASSWORD'] ),
-				'database' => sanitize_text_field( $_SERVER['CACHE_DB'] ),
+				'port' => isset( $_SERVER['CACHE_PORT'] ) ? sanitize_text_field( $_SERVER['CACHE_PORT'] ) : 6379,
+				'auth' => isset( $_SERVER['CACHE_PASSWORD'] ) ? sanitize_text_field( $_SERVER['CACHE_PASSWORD'] ) : null,
+				'database' => isset( $_SERVER['CACHE_DB'] ) ? sanitize_text_field( $_SERVER['CACHE_DB'] ) : 0,
 			];
 		} else {
 			$redis_server = [


### PR DESCRIPTION
* Fixes #359
* Falls back on port 6379 if the CACHE_PORT is not configured.
* Doesn't require a CACHE_PASSWORD to be set when it isn't used, or can't be.
* Improves code quality by reducing Redis default port & databasei duplicate values to a share variables.
* Fixes invalid code changes made in PR [#400 ](https://github.com/pantheon-systems/wp-redis/pull/400) to the core plugin connectivity testing that prevent connectivty checks if the port/password/database aren't explicitly defined.
