### PR TITLE
Fix slug in publishing workflow

### DIFF
--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -13,4 +13,4 @@ jobs:
       env:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        SLUG: ${{ env.SLUG }}
+        SLUG: wp-redis


### PR DESCRIPTION
I seems there are no environment variables.
:) plugin slug changes every 1000 years