### PR TITLE
[BUGS-6248] Only flush local cache

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -165,7 +165,9 @@ function wp_cache_get_multiple( $keys, $group = '', $force = false ) {
  * @return bool True on success, false on failure.
  */
 function wp_cache_flush_runtime() {
-	return wp_cache_flush();
+	global $wp_object_cache;
+
+	return $wp_object_cache->flush( false );
 }
 
 /**


### PR DESCRIPTION
Introduced in https://github.com/pantheon-systems/wp-redis/pull/405. 

`wp_cache_flush_runtime` should not clear redis cache as well, just local runtime cache values. By passing false to flush method, only runtime caches are flushed. 