### PR TITLE
[BUGS-6248] wp_cache_flush_runtime should only clear local cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 ## Changelog ##
 
 ### Latest ###
-
+* Bug fix: `wp_cache_flush_runtime` should only clear the local cache [[413](https://github.com/pantheon-systems/wp-redis/pull/413)]
 
 ### 1.4.0 (May 9, 2023) ###
 * Add support for `flush_runtime` and `flush_group` functions [[#405](https://github.com/pantheon-systems/wp-redis/pull/405)]

--- a/object-cache.php
+++ b/object-cache.php
@@ -165,7 +165,9 @@ function wp_cache_get_multiple( $keys, $group = '', $force = false ) {
  * @return bool True on success, false on failure.
  */
 function wp_cache_flush_runtime() {
-	return wp_cache_flush();
+	global $wp_object_cache;
+
+	return $wp_object_cache->flush( false );
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -103,7 +103,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 == Changelog ==
 
 = Latest =
-
+* Bug fix: `wp_cache_flush_runtime` should only clear the local cache [[413](https://github.com/pantheon-systems/wp-redis/pull/413)]
 
 = 1.4.0 (May 9, 2023) =
 * Add support for `flush_runtime` and `flush_group` functions [[#405](https://github.com/pantheon-systems/wp-redis/pull/405)]

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -410,7 +410,7 @@ class CacheTest extends WP_UnitTestCase {
 		// Flush the cache
 		wp_cache_flush_runtime();
 
-		// If we are using redis, verify redis cache was not flished
+		// If we are using redis, verify redis cache was not flushed
 		if ($this->cache->is_redis_connected) {
 			foreach ( $data as $key => $value ) {
 				$this->assertEquals( $value, wp_cache_get( $key, 'test_wp_cache_flush_runtime' ) );

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -410,7 +410,15 @@ class CacheTest extends WP_UnitTestCase {
 		// Flush the cache
 		wp_cache_flush_runtime();
 
-		// Verify that the cache is now empty
+		// If we are using redis, verify redis cache was not flished
+		if ($this->cache->is_redis_connected) {
+			foreach ( $data as $key => $value ) {
+				$this->assertEquals( $value, wp_cache_get( $key, 'test_wp_cache_flush_runtime' ) );
+			}
+			return
+		}
+
+		// If we are not using redis, verify the cache is now empty
 		foreach ($data as $key => $value) {
 			$this->assertFalse( wp_cache_get( $key, 'test_wp_cache_flush_runtime' ) );
 		}

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -415,7 +415,7 @@ class CacheTest extends WP_UnitTestCase {
 			foreach ( $data as $key => $value ) {
 				$this->assertEquals( $value, wp_cache_get( $key, 'test_wp_cache_flush_runtime' ) );
 			}
-			return
+			return;
 		}
 
 		// If we are not using redis, verify the cache is now empty


### PR DESCRIPTION
Follows #405 
Replaces #412. Cherry-picked over in order to fix & run unit tests.
> Introduced in https://github.com/pantheon-systems/wp-redis/pull/405.
> wp_cache_flush_runtime should not clear redis cache as well, just local runtime cache values. By passing false to flush method, only runtime caches are flushed.

Props @spacedmonkey for the fix.