### PR TITLE
Release 1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Tags:** cache, plugin, redis
 **Requires at least:** 3.0.1
 **Tested up to:** 6.2
-**Stable tag:** 1.4.0
+**Stable tag:** 1.4.1-dev
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -103,6 +103,9 @@ This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `
 There's a known issue with WordPress `alloptions` cache design. Specifically, a race condition between two requests can cause the object cache to have stale values. If you think you might be impacted by this, [review this GitHub issue](https://github.com/pantheon-systems/wp-redis/issues/221) for links to more context, including a workaround.
 
 ## Changelog ##
+
+### Latest ###
+
 
 ### 1.4.0 (May 9, 2023) ###
 * Add support for `flush_runtime` and `flush_group` functions [[#405](https://github.com/pantheon-systems/wp-redis/pull/405)]

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 ## Changelog ##
 
 ### Latest ###
-
+* Bug fix: `wp_cache_flush_runtime` should only clear the local cache [[413](https://github.com/pantheon-systems/wp-redis/pull/413)]
 
 ### 1.4.0 (May 9, 2023) ###
 * Add support for `flush_runtime` and `flush_group` functions [[#405](https://github.com/pantheon-systems/wp-redis/pull/405)]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Back your WP Object Cache with Redis, a high-performance in-memory storage backe
 
 ## Description ##
 
-[![Travis CI](https://travis-ci.org/pantheon-systems/wp-redis.svg?branch=master)](https://travis-ci.org/pantheon-systems/wp-redis) [![CircleCI](https://circleci.com/gh/pantheon-systems/wp-redis/tree/master.svg?style=svg)](https://circleci.com/gh/pantheon-systems/wp-redis/tree/master)
+[![CircleCI](https://circleci.com/gh/pantheon-systems/wp-redis/tree/master.svg?style=svg)](https://circleci.com/gh/pantheon-systems/wp-redis/tree/master)
 
 For sites concerned with high traffic, speed for logged-in users, or dynamic pageloads, a high-speed and persistent object cache is a must. You also need something that can scale across multiple instances of your application, so using local file caches or APC are out.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Tags:** cache, plugin, redis
 **Requires at least:** 3.0.1
 **Tested up to:** 6.2
-**Stable tag:** 1.4.1-dev
+**Stable tag:** 1.4.1
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -104,7 +104,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 
 ## Changelog ##
 
-### Latest ###
+### 1.4.1 (May 11, 2023) ###
 * Bug fix: `wp_cache_flush_runtime` should only clear the local cache [[413](https://github.com/pantheon-systems/wp-redis/pull/413)]
 
 ### 1.4.0 (May 9, 2023) ###

--- a/object-cache.php
+++ b/object-cache.php
@@ -165,7 +165,9 @@ function wp_cache_get_multiple( $keys, $group = '', $force = false ) {
  * @return bool True on success, false on failure.
  */
 function wp_cache_flush_runtime() {
-	return wp_cache_flush();
+	global $wp_object_cache;
+
+	return $wp_object_cache->flush( false );
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon, danielbachhuber, mboynes, Outlandish Josh, jspellman,
 Tags: cache, plugin, redis
 Requires at least: 3.0.1
 Tested up to: 6.2
-Stable tag: 1.4.1-dev
+Stable tag: 1.4.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -102,7 +102,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 
 == Changelog ==
 
-= Latest =
+= 1.4.1 (May 11, 2023) =
 * Bug fix: `wp_cache_flush_runtime` should only clear the local cache [[413](https://github.com/pantheon-systems/wp-redis/pull/413)]
 
 = 1.4.0 (May 9, 2023) =

--- a/readme.txt
+++ b/readme.txt
@@ -103,7 +103,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 == Changelog ==
 
 = Latest =
-
+* Bug fix: `wp_cache_flush_runtime` should only clear the local cache [[413](https://github.com/pantheon-systems/wp-redis/pull/413)]
 
 = 1.4.0 (May 9, 2023) =
 * Add support for `flush_runtime` and `flush_group` functions [[#405](https://github.com/pantheon-systems/wp-redis/pull/405)]

--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ Back your WP Object Cache with Redis, a high-performance in-memory storage backe
 
 == Description ==
 
-[![Travis CI](https://travis-ci.org/pantheon-systems/wp-redis.svg?branch=master)](https://travis-ci.org/pantheon-systems/wp-redis) [![CircleCI](https://circleci.com/gh/pantheon-systems/wp-redis/tree/master.svg?style=svg)](https://circleci.com/gh/pantheon-systems/wp-redis/tree/master)
+[![CircleCI](https://circleci.com/gh/pantheon-systems/wp-redis/tree/master.svg?style=svg)](https://circleci.com/gh/pantheon-systems/wp-redis/tree/master)
 
 For sites concerned with high traffic, speed for logged-in users, or dynamic pageloads, a high-speed and persistent object cache is a must. You also need something that can scale across multiple instances of your application, so using local file caches or APC are out.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon, danielbachhuber, mboynes, Outlandish Josh, jspellman,
 Tags: cache, plugin, redis
 Requires at least: 3.0.1
 Tested up to: 6.2
-Stable tag: 1.4.0
+Stable tag: 1.4.1-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `
 There's a known issue with WordPress `alloptions` cache design. Specifically, a race condition between two requests can cause the object cache to have stale values. If you think you might be impacted by this, [review this GitHub issue](https://github.com/pantheon-systems/wp-redis/issues/221) for links to more context, including a workaround.
 
 == Changelog ==
+
+= Latest =
+
 
 = 1.4.0 (May 9, 2023) =
 * Add support for `flush_runtime` and `flush_group` functions [[#405](https://github.com/pantheon-systems/wp-redis/pull/405)]

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -410,7 +410,15 @@ class CacheTest extends WP_UnitTestCase {
 		// Flush the cache
 		wp_cache_flush_runtime();
 
-		// Verify that the cache is now empty
+		// If we are using redis, verify redis cache was not flushed
+		if ($this->cache->is_redis_connected) {
+			foreach ( $data as $key => $value ) {
+				$this->assertEquals( $value, wp_cache_get( $key, 'test_wp_cache_flush_runtime' ) );
+			}
+			return;
+		}
+
+		// If we are not using redis, verify the cache is now empty
 		foreach ($data as $key => $value) {
 			$this->assertFalse( wp_cache_get( $key, 'test_wp_cache_flush_runtime' ) );
 		}

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Redis
  * Plugin URI: http://github.com/pantheon-systems/wp-redis/
  * Description: WordPress Object Cache using Redis. Requires the PhpRedis extension (https://github.com/phpredis/phpredis).
- * Version: 1.4.0
+ * Version: 1.4.1-dev
  * Author: Pantheon, Josh Koenig, Matthew Boynes, Daniel Bachhuber, Alley Interactive
  * Author URI: https://pantheon.io/
  */

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Redis
  * Plugin URI: http://github.com/pantheon-systems/wp-redis/
  * Description: WordPress Object Cache using Redis. Requires the PhpRedis extension (https://github.com/phpredis/phpredis).
- * Version: 1.4.1-dev
+ * Version: 1.4.1
  * Author: Pantheon, Josh Koenig, Matthew Boynes, Daniel Bachhuber, Alley Interactive
  * Author URI: https://pantheon.io/
  */


### PR DESCRIPTION
## Changes:
* Bug fix: `wp_cache_flush_runtime` should only clear the local cache [[413](https://github.com/pantheon-systems/wp-redis/pull/413)]
