### PR TITLE
[CI] Move common phpunit steps to commands to shorten up circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
-version: 2
+version: 2.1
 workflows:
-  version: 2
   main:
     jobs:
       - lint
@@ -19,6 +18,45 @@ workflows:
                 - release
     jobs:
       - test-behat
+
+commands:
+  install-extras:
+    steps:
+      - run:
+          name: "Install Extra Dependencies"
+          command: |
+            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
+            sudo apt-get update
+            sudo apt-get install subversion
+            sudo apt-get install -y libmagickwand-dev --no-install-recommends
+            yes '' | sudo pecl install imagick || true
+            sudo docker-php-ext-enable imagick
+            sudo docker-php-ext-install mysqli
+  install-mariadb-10-5:
+    steps:
+      - run: sudo apt-get install mariadb-client-10.5
+  install-mariadb-10-6:
+    steps:
+      - run: sudo apt-get install mariadb-client-10.6
+  install-redis-extras:
+    steps:
+      - run: 
+          name: "Install Redis Extras"
+          command: |
+            yes '' | sudo pecl install redis || true
+            sudo docker-php-ext-enable redis
+  run-phpunit-tests:
+    steps:
+      - run:
+          name: "Run Tests"
+          command: |
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+            composer phpunit
+            WP_MULTISITE=1 composer phpunit
+            WP_REDIS_USE_CACHE_GROUPS=1 composer phpunit
+            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 nightly true
+            composer phpunit
 jobs:
   lint:
     working_directory: ~/pantheon-systems/wp-redis
@@ -38,6 +76,7 @@ jobs:
           name: "Run PHP Lint"
           command: |
             composer phpcs
+
   test-behat:
     working_directory: ~/pantheon-systems/wp-redis
     parallelism: 1
@@ -102,27 +141,9 @@ jobs:
           key: test-phpunit-74-dependencies-{{ checksum "composer.json" }}
           paths:
             - vendor
-      - run:
-          name: "Install Extras"
-          command: |
-            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
-            sudo apt-get update
-            sudo apt-get install subversion
-            sudo apt-get install -y libmagickwand-dev --no-install-recommends
-            yes '' | sudo pecl install imagick || true
-            sudo docker-php-ext-enable imagick
-            sudo docker-php-ext-install mysqli
-            sudo apt-get install mariadb-client-10.5
-      - run:
-          name: "Run Tests"
-          command: |
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
-            composer phpunit
-            WP_MULTISITE=1 composer phpunit
-            WP_REDIS_USE_CACHE_GROUPS=1 composer phpunit
-            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 nightly true
-            composer phpunit
+      - install-extras
+      - install-mariadb-10-5
+      - run-phpunit-tests
   test-phpunit-redis-enabled-74:
     working_directory: ~/pantheon-systems/wp-redis
     docker:
@@ -143,29 +164,10 @@ jobs:
           key: test-phpunit-74-dependencies-{{ checksum "composer.json" }}
           paths:
             - vendor
-      - run:
-          name: "Install Extras"
-          command: |
-            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
-            sudo apt-get update
-            sudo apt-get install subversion
-            sudo apt-get install -y libmagickwand-dev --no-install-recommends
-            yes '' | sudo pecl install imagick || true
-            sudo docker-php-ext-enable imagick
-            sudo docker-php-ext-install mysqli
-            sudo apt-get install mariadb-client-10.5
-            yes '' | sudo pecl install redis || true
-            sudo docker-php-ext-enable redis
-      - run:
-          name: "Run Tests"
-          command: |
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
-            composer phpunit
-            WP_MULTISITE=1 composer phpunit
-            WP_REDIS_USE_CACHE_GROUPS=1 composer phpunit
-            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 nightly true
-            composer phpunit
+      - install-extras
+      - install-mariadb-10-5
+      - install-redis-extras
+      - run-phpunit-tests
   test-phpunit-redis-disabled-82:
     working_directory: ~/pantheon-systems/wp-redis
     docker:
@@ -184,27 +186,9 @@ jobs:
           key: test-phpunit-82-dependencies-{{ checksum "composer.json" }}
           paths:
             - vendor
-      - run:
-          name: "Install Extras"
-          command: |
-            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
-            sudo apt-get update
-            sudo apt-get install subversion
-            sudo apt-get install -y libmagickwand-dev --no-install-recommends
-            yes '' | sudo pecl install imagick || true
-            sudo docker-php-ext-enable imagick
-            sudo docker-php-ext-install mysqli
-            sudo apt-get install mariadb-client-10.6
-      - run:
-          name: "Run Tests"
-          command: |
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
-            composer phpunit
-            WP_MULTISITE=1 composer phpunit
-            WP_REDIS_USE_CACHE_GROUPS=1 composer phpunit
-            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 nightly true
-            composer phpunit
+      - install-extras
+      - install-mariadb-10-6
+      - run-phpunit-tests
   test-phpunit-redis-enabled-82:
     working_directory: ~/pantheon-systems/wp-redis
     docker:
@@ -224,26 +208,7 @@ jobs:
           key: test-phpunit-82-dependencies-{{ checksum "composer.json" }}
           paths:
             - vendor
-      - run:
-          name: "Install Extras"
-          command: |
-            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
-            sudo apt-get update
-            sudo apt-get install subversion
-            sudo apt-get install -y libmagickwand-dev --no-install-recommends
-            yes '' | sudo pecl install imagick || true
-            sudo docker-php-ext-enable imagick
-            sudo docker-php-ext-install mysqli
-            sudo apt-get install mariadb-client-10.6
-            yes '' | sudo pecl install redis || true
-            sudo docker-php-ext-enable redis
-      - run:
-          name: "Run Tests"
-          command: |
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
-            composer phpunit
-            WP_MULTISITE=1 composer phpunit
-            WP_REDIS_USE_CACHE_GROUPS=1 composer phpunit
-            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 nightly true
-            composer phpunit
+      - install-extras
+      - install-mariadb-10-6
+      - install-redis-extras
+      - run-phpunit-tests


### PR DESCRIPTION
Working on #415, I ended up cleaning up the circle config file quite a bit, but while the new CLI bash script is not quite ready, I'd like to get the phpunit test cleanup in place.

Incidentally, maintaining these dependencies in a separate image re-used would mean ~1 minute off each test.