### PR TITLE
[CMSP-390] esc_html in trigger_error causes an exception loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 ## Changelog ##
 
 ### Latest ###
+* Bug fix: Removes exception loop caused by `esc_html` in `_exception_handler()` [[421](https://github.com/pantheon-systems/wp-redis/pull/421)]
 
 ### 1.4.1 (May 11, 2023) ###
 * Bug fix: `wp_cache_flush_runtime` should only clear the local cache [[413](https://github.com/pantheon-systems/wp-redis/pull/413)]

--- a/object-cache.php
+++ b/object-cache.php
@@ -1470,7 +1470,9 @@ class WP_Object_Cache {
 		try {
 			$this->last_triggered_error = 'WP Redis: ' . $exception->getMessage();
 			// Be friendly to developers debugging production servers by triggering an error.
-			trigger_error( esc_html( $this->last_triggered_error ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error,WordPress.Security.EscapeOutput.OutputNotEscaped
+			trigger_error( $this->last_triggered_error, E_USER_WARNING ); 
 		} catch ( PHPUnit_Framework_Error_Warning $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// PHPUnit throws an Exception when `trigger_error()` is called. To ensure our tests (which expect Exceptions to be caught) continue to run, we catch the PHPUnit exception and inspect the RedisException message.
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 == Changelog ==
 
 = Latest =
+* Bug fix: Removes exception loop caused by `esc_html` in `_exception_handler()` [[421](https://github.com/pantheon-systems/wp-redis/pull/421)]
 
 = 1.4.1 (May 11, 2023) =
 * Bug fix: `wp_cache_flush_runtime` should only clear the local cache [[413](https://github.com/pantheon-systems/wp-redis/pull/413)]


### PR DESCRIPTION
`esc_html` causes a fatal error with an exception loop. This drops the escaping and adds an ignore for the codesniffer. HM standards (partially upstream of [our own](https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards)) advocate for ignoring on all instances of `trigger_error`, but holding off making that global change.
* ~~hold for #419~~
* Addresses #418, #410 _(will not mark as fixes until release PR)_
