### PR TITLE
[BUGS-6318] Handle warning if open_basedir is in use and a socket is being used.

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -1293,6 +1293,7 @@ class WP_Object_Cache {
 			$client_parameters['port'],
 			// $client_parameters['timeout'] is sent in milliseconds, connect() takes seconds, so divide by 1000.
 			$client_parameters['timeout'] / 1000,
+			null,
 			$client_parameters['retry_interval']
 		);
 

--- a/object-cache.php
+++ b/object-cache.php
@@ -1293,7 +1293,6 @@ class WP_Object_Cache {
 			$client_parameters['port'],
 			// $client_parameters['timeout'] is sent in milliseconds, connect() takes seconds, so divide by 1000.
 			$client_parameters['timeout'] / 1000,
-			null,
 			$client_parameters['retry_interval']
 		);
 

--- a/object-cache.php
+++ b/object-cache.php
@@ -1256,7 +1256,7 @@ class WP_Object_Cache {
 			}
 		}
 
-		if ( file_exists( $redis_server['host'] ) && 'socket' === filetype( $redis_server['host'] ) ) { // unix socket connection.
+		if (strpos($redis_server['host'], 'unix:///') === 0) { // Unix socket connection. 
 			// port must be null or socket won't connect.
 			$port = null;
 		} else { // tcp connection.


### PR DESCRIPTION
Connect via unix socket instead of filesystem to be compatible with php open_basedir restrictions.