### PR TITLE
[CMSP-459] Updates behat tests and behaviors.

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -3,7 +3,7 @@ default:
   suites:
     default:
       paths:
-        - tests/behat
+        - tests/behat/
       contexts:
         - Behat\MinkExtension\Context\MinkContext
         - PantheonSystems\PantheonWordPressUpstreamTests\Behat\AdminLogIn

--- a/behat.yml
+++ b/behat.yml
@@ -7,6 +7,7 @@ default:
       contexts:
         - Behat\MinkExtension\Context\MinkContext
         - PantheonSystems\PantheonWordPressUpstreamTests\Behat\AdminLogIn
+        - behat\features\bootstrap\WpRedisFeatureContext
   extensions:
     Behat\MinkExtension:
       # base_url set by ENV

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -30,9 +30,6 @@ set -ex
 terminus env:create  $TERMINUS_SITE.dev $TERMINUS_ENV
 terminus env:wipe $SITE_ENV --yes
 
-# Enable Redis
-terminus redis:enable $TERMINUS_SITE
-
 ###
 # Get all necessary environment details.
 ###

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,9 @@
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true
     }
+  },
+  "autoload": {
+    "psr-4": { "behat\\features\\bootstrap\\": "tests/behat/features/bootstrap/" }
   }
+
 }

--- a/tests/behat/features/bootstrap/WpRedisFeatureContext.php
+++ b/tests/behat/features/bootstrap/WpRedisFeatureContext.php
@@ -1,0 +1,35 @@
+<?php
+// features/bootstrap/WPRedisFeatureContext.php
+
+namespace behat\features\bootstrap;
+
+use Behat\Behat\Context\Context;
+
+class WpRedisFeatureContext implements Context
+{
+
+    /**
+     * Initializes context.
+     *
+     * Every scenario gets its own context instance.
+     * You can also pass arbitrary arguments to the
+     * context constructor through behat.yml.
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Waits a certain number of seconds.
+     *
+     * @param int $seconds
+     *   How long to wait.
+     *
+     * @When I wait :seconds second(s)
+     */
+    public function wait($seconds)
+    {
+        sleep($seconds);
+    }
+
+}

--- a/tests/behat/load-wp.feature
+++ b/tests/behat/load-wp.feature
@@ -22,6 +22,7 @@ Feature: Load WordPress
     When I go to "/wp-admin/options-general.php"
     And I fill in "blogname" with "Pantheon WordPress Site"
     And I press "submit"
+    When I wait "1" second
     Then print current URL
     And I should see "Settings saved."
 

--- a/tests/behat/wp-redis.feature
+++ b/tests/behat/wp-redis.feature
@@ -15,10 +15,10 @@ Feature: WP Redis
     Then I should see "Redis Calls:"
     And I should see "Cache Hits:"
     And I should see "Cache Misses:"
-    And I should see "Redis Calls:"
 
     # We call the same page twice to give Redis an opportunity to cache
     # something so that `get` actually fires.
     When I am on "/?redis_debug"
     Then I should see "Group:"
-    Then I should see "- get"
+    # Uncomment this test when PR #426 is merged.
+    # Then I should see "- get"

--- a/tests/behat/wp-redis.feature
+++ b/tests/behat/wp-redis.feature
@@ -15,10 +15,10 @@ Feature: WP Redis
     Then I should see "Redis Calls:"
     And I should see "Cache Hits:"
     And I should see "Cache Misses:"
+		And I should see "Redis Calls:"
 
     # We call the same page twice to give Redis an opportunity to cache
     # something so that `get` actually fires.
     When I am on "/?redis_debug"
     Then I should see "Group:"
-    # Uncomment this test when PR #426 is merged.
-    # Then I should see "- get"
+    Then I should see "- get"

--- a/tests/behat/wp-redis.feature
+++ b/tests/behat/wp-redis.feature
@@ -15,4 +15,10 @@ Feature: WP Redis
     Then I should see "Redis Calls:"
     And I should see "Cache Hits:"
     And I should see "Cache Misses:"
-    And I should see "- get:"
+    And I should see "Redis Calls:"
+
+    # We call the same page twice to give Redis an opportunity to cache
+    # something so that `get` actually fires.
+    When I am on "/?redis_debug"
+    Then I should see "Group:"
+    Then I should see "- get"

--- a/tests/behat/wp-redis.feature
+++ b/tests/behat/wp-redis.feature
@@ -15,7 +15,7 @@ Feature: WP Redis
     Then I should see "Redis Calls:"
     And I should see "Cache Hits:"
     And I should see "Cache Misses:"
-		And I should see "Redis Calls:"
+    And I should see "Redis Calls:"
 
     # We call the same page twice to give Redis an opportunity to cache
     # something so that `get` actually fires.


### PR DESCRIPTION
Ports behat fixes from https://github.com/pantheon-systems/wp-redis/pull/429/files into its own PR.

This PR also removes the `terminus redis:enable` step in `bin/behat-prepare.sh`. There's no reason to ever _disable_ redis on the fixture running Behat tests, and the enable step spawns many duplicate "redis enable" requests, most of which time-out, causing the tests to fail.

Tests can be seen as passing (with #437) here: https://app.circleci.com/pipelines/github/pantheon-systems/wp-redis/1629/workflows/fd714abf-075f-45f8-9102-3ddc730f731e/jobs/4980