### PR TITLE
add wporg validator action

### DIFF
--- a/.github/workflows/wporg-validator.yml
+++ b/.github/workflows/wporg-validator.yml
@@ -1,0 +1,8 @@
+# On push, run the action-wporg-validator workflow.
+name: WP.org Validator
+on: [push]
+jobs:
+  wporg-validation:
+    uses: pantheon-systems/action-wporg-validator@1.0.0
+    with:
+      type: plugin

--- a/.github/workflows/wporg-validator.yml
+++ b/.github/workflows/wporg-validator.yml
@@ -3,6 +3,11 @@ name: WP.org Validator
 on: [push]
 jobs:
   wporg-validation:
-    uses: pantheon-systems/action-wporg-validator@1.0.0
-    with:
-      type: plugin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: WP.org Validator
+        uses: pantheon-systems/action-wporg-validator@1.0.0
+        with:
+          type: plugin

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 
 ### 1.4.3-dev ###
 * Bug fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set. [[428](https://github.com/pantheon-systems/wp-redis/pull/428)] (props @timnolte)
+* Adds WP.org validation GitHub action [[#435](https://github.com/pantheon-systems/wp-redis/pull/435)]
 
 ### 1.4.2 (May 15, 2023) ###
 * Bug fix: Removes exception loop caused by `esc_html` in `_exception_handler()` [[421](https://github.com/pantheon-systems/wp-redis/pull/421)]

--- a/cli.php
+++ b/cli.php
@@ -41,7 +41,7 @@ class WP_Redis_CLI_Command {
 		$cmd = WP_CLI\Utils\esc_cmd( 'redis-cli -h %s -p %s -a %s -n %s', $redis_server['host'], $redis_server['port'], $redis_server['auth'], $redis_server['database'] );
 		$process = WP_CLI\Utils\proc_open_compat( $cmd, [ STDIN, STDOUT, STDERR ], $pipes );
 		$r = proc_close( $process );
-		exit( (int) $r );
+		exit( (int) $r ); // phpcs:ignore WordPressDotOrg.sniffs.OutputEscaping.UnescapedOutputParameter
 	}
 
 	/**

--- a/object-cache.php
+++ b/object-cache.php
@@ -986,7 +986,7 @@ class WP_Object_Cache {
 			$out[] = '<li><strong>Group:</strong> ' . esc_html( $group ) . ' - ( ' . number_format( strlen( serialize( $cache ) ) / 1024, 2 ) . 'k )</li>';
 		}
 		$out[] = '</ul>';
-		echo implode( PHP_EOL, $out ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped WordPressDotOrg.sniffs.OutputEscaping.UnescapedOutputParameter
+		echo implode( PHP_EOL, $out ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped,WordPressDotOrg.sniffs.OutputEscaping.UnescapedOutputParameter
 	}
 
 	/**

--- a/object-cache.php
+++ b/object-cache.php
@@ -986,7 +986,7 @@ class WP_Object_Cache {
 			$out[] = '<li><strong>Group:</strong> ' . esc_html( $group ) . ' - ( ' . number_format( strlen( serialize( $cache ) ) / 1024, 2 ) . 'k )</li>';
 		}
 		$out[] = '</ul>';
-		echo implode( PHP_EOL, $out ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo implode( PHP_EOL, $out ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped WordPressDotOrg.sniffs.OutputEscaping.UnescapedOutputParameter
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 
 = 1.4.3-dev =
 * Bug fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set. [[428](https://github.com/pantheon-systems/wp-redis/pull/428)] (props @tnolte)
+* Adds WP.org validation GitHub action [[#435](https://github.com/pantheon-systems/wp-redis/pull/435)]
 
 = 1.4.2 (May 15, 2023) =
 * Bug fix: Removes exception loop caused by `esc_html` in `_exception_handler()` [[421](https://github.com/pantheon-systems/wp-redis/pull/421)]


### PR DESCRIPTION
Adds our [WP.org plugin validator action](https://github.com/marketplace/actions/wp-org-plugin-theme-validator).

Ignores a couple sniffs on not sanitizing output.