### PR TITLE
[CMSP-459] bugfix: re-add missing else

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -1265,7 +1265,7 @@ class WP_Object_Cache {
 			// port must be null or socket won't connect.
 			$port = null;
 		} else { // tcp connection.
-			$port = ! empty( $redis_server['port'] ) ? $redis_server['port'] : 6379;
+			$port = ! empty( $redis_server['port'] ) ? $redis_server['port'] : $port;
 		}
 
 		$defaults = [

--- a/object-cache.php
+++ b/object-cache.php
@@ -1264,6 +1264,8 @@ class WP_Object_Cache {
 		if ( file_exists( $redis_server['host'] ) && 'socket' === filetype( $redis_server['host'] ) ) { // unix socket connection.
 			// port must be null or socket won't connect.
 			$port = null;
+		} else { // tcp connection.
+			$port = ! empty( $redis_server['port'] ) ? $redis_server['port'] : 6379;
 		}
 
 		$defaults = [

--- a/object-cache.php
+++ b/object-cache.php
@@ -1264,8 +1264,8 @@ class WP_Object_Cache {
 		if ( file_exists( $redis_server['host'] ) && 'socket' === filetype( $redis_server['host'] ) ) { // unix socket connection.
 			// port must be null or socket won't connect.
 			$port = null;
-		} else { // tcp connection.
-			$port = ! empty( $redis_server['port'] ) ? $redis_server['port'] : $port;
+		} elseif ( ! empty( $redis_server['port'] ) ) { // tcp connection.
+			$port = $redis_server['port'];
 		}
 
 		$defaults = [


### PR DESCRIPTION
This re-adds the else statement that was inadvertently missed in a recent commit, leading to some of the Behat test failures.

This, as well as #430 account for all of the environment fixes that were mixed into #426 but separate from the actual change suggested in that PR.

Tests can be seen as passing (with #430) here: https://app.circleci.com/pipelines/github/pantheon-systems/wp-redis/1629/workflows/fd714abf-075f-45f8-9102-3ddc730f731e/jobs/4980