### PR TITLE
Release 1.4.3

### DIFF
--- a/.github/workflows/wporg-validator.yml
+++ b/.github/workflows/wporg-validator.yml
@@ -1,0 +1,13 @@
+# On push, run the action-wporg-validator workflow.
+name: WP.org Validator
+on: [push]
+jobs:
+  wporg-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: WP.org Validator
+        uses: pantheon-systems/action-wporg-validator@1.0.0
+        with:
+          type: plugin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We prefer to squash commits (i.e. avoid merge PRs) from a feature branch into `d
 
 `default` should be stable and usable, though possibly a few commits ahead of the public release on wp.org.
 
-The `release` branch matches the latest stable release deployed to [wp.org](wp.org).
+The `release` branch matches the latest stable release deployed to [wp.org](https://wordpress.org/).
 
 ## Testing
 
@@ -33,13 +33,13 @@ The behat tests require a Pantheon site with Redis enabled. Once you've created 
 
 1. From `default`, checkout a new branch `release_X.Y.Z`.
 1. Make a release commit:
-    * Drop the `-dev` from the version number in `README.md`, `readme.txt`, and `wp-redis.php`.
-    * Update the "Latest" heading in the changelog to the new version number with the date
+    * In `README.md`, `readme.txt`, and `wp-redis.php`, remove the `-dev` from the version number. For the README files. the version number must be updated both at the top of the document as well as the changelog.
+    * Add the date to the `** X.Y.X **` heading in the changelogs in README.md, readme.txt, and any other appropriate location.
     * Commit these changes with the message `Release X.Y.Z`
     * Push the release branch up.
 1. Open a Pull Request to merge `release_X.Y.Z` into `release`. Your PR should consist of all commits to `default` since the last release, and one commit to update the version number. The PR name should also be `Release X.Y.Z`.
 1. After all tests pass and you have received approval from a [CODEOWNER](./CODEOWNERS), merge the PR into `release`. "Rebase and merge" is preferred in this case. _Never_ squash to `release`.
-1. Pull `release` locally, create a new tag (based on version number from previous steps), and push up. The tag should _only_ be the version number. It _should not_ be prefixed  `v` (i.e. `X.Y.Z`, not `vX.Y.X`).
+1. Locally, pull the `release` branch, create a new tag (based on version number from previous steps), and push up. The tag should _only_ be the version number. It _should not_ be prefixed  `v` (i.e. `X.Y.Z`, not `vX.Y.X`).
     * `git tag X.Y.Z`
     * `git push --tags`
 1. Confirm that the necessary assets are present in the newly created tag, and test on a WP install if desired.
@@ -47,10 +47,12 @@ The behat tests require a Pantheon site with Redis enabled. Once you've created 
 1. Wait for the [_Release wp-redis plugin to wp.org_ action](https://github.com/pantheon-systems/wp-redis/actions/workflows/wordpress-plugin-deploy.yml) to finish deploying to the WordPress.org plugin repository. If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
 1. Check WordPress.org: Ensure that the changes are live on [the plugin repository](https://wordpress.org/plugins/wp-redis/). This may take a few minutes.
 1. Following the release, prepare the next dev version with the following steps:
-    * `git checkout develop`
-    * `git rebase master`
+    * `git checkout release`
+    * `git pull origin release`
+    * `git checkout default`
+    * `git rebase release`
     * Update the version number in all locations, incrementing the version by one patch version, and add the `-dev` flag (e.g. after releasing `1.2.3`, the new verison will be `1.2.4-dev`)
-    * Add a new `** Latest **` heading to the changelog
+    * Add a new `** X.Y.X-dev **` heading to the changelog
     * `git add -A .`
     * `git commit -m "Prepare X.Y.X-dev"`
-    * `git push origin develop`
+    * `git push origin default`

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 
 ## Changelog ##
 
-### Latest ###
+### 1.4.3-dev ###
+* Bug fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set. [[428](https://github.com/pantheon-systems/wp-redis/pull/428)] (props @timnolte)
 
 ### 1.4.2 (May 15, 2023) ###
 * Bug fix: Removes exception loop caused by `esc_html` in `_exception_handler()` [[421](https://github.com/pantheon-systems/wp-redis/pull/421)]

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 
 ### 1.4.3-dev ###
 * Bug fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set. [[428](https://github.com/pantheon-systems/wp-redis/pull/428)] (props @timnolte)
+* Adds WP.org validation GitHub action [[#435](https://github.com/pantheon-systems/wp-redis/pull/435)]
 
 ### 1.4.2 (May 15, 2023) ###
 * Bug fix: Removes exception loop caused by `esc_html` in `_exception_handler()` [[421](https://github.com/pantheon-systems/wp-redis/pull/421)]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Tags:** cache, plugin, redis
 **Requires at least:** 3.0.1
 **Tested up to:** 6.2
-**Stable tag:** 1.4.3-dev
+**Stable tag:** 1.4.3
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -104,7 +104,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 
 ## Changelog ##
 
-### 1.4.3-dev ###
+### 1.4.3 (June 26, 2023) ###
 * Bug fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set. [[428](https://github.com/pantheon-systems/wp-redis/pull/428)] (props @timnolte)
 * Adds WP.org validation GitHub action [[#435](https://github.com/pantheon-systems/wp-redis/pull/435)]
 * Bug fix: Fixes incorrect order of `array_replace_recursive` and other issues [[434](https://github.com/pantheon-systems/wp-redis/pull/434)] (props @timnolte)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Tags:** cache, plugin, redis
 **Requires at least:** 3.0.1
 **Tested up to:** 6.2
-**Stable tag:** 1.4.2
+**Stable tag:** 1.4.3-dev
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -103,6 +103,8 @@ This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `
 There's a known issue with WordPress `alloptions` cache design. Specifically, a race condition between two requests can cause the object cache to have stale values. If you think you might be impacted by this, [review this GitHub issue](https://github.com/pantheon-systems/wp-redis/issues/221) for links to more context, including a workaround.
 
 ## Changelog ##
+
+### Latest ###
 
 ### 1.4.2 (May 15, 2023) ###
 * Bug fix: Removes exception loop caused by `esc_html` in `_exception_handler()` [[421](https://github.com/pantheon-systems/wp-redis/pull/421)]

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 ### 1.4.3-dev ###
 * Bug fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set. [[428](https://github.com/pantheon-systems/wp-redis/pull/428)] (props @timnolte)
 * Adds WP.org validation GitHub action [[#435](https://github.com/pantheon-systems/wp-redis/pull/435)]
+* Bug fix: Fixes incorrect order of `array_replace_recursive` and other issues [[434](https://github.com/pantheon-systems/wp-redis/pull/434)] (props @timnolte)
+* Bug fix: Replace use of wp_strip_all_tags in object-cache.php [[434](https://github.com/pantheon-systems/wp-redis/pull/434)] (props @timnolte)
+* Bug fix: Don't strip tags from the cache password. [[434](https://github.com/pantheon-systems/wp-redis/pull/434)] (props @timnolte)
 
 ### 1.4.2 (May 15, 2023) ###
 * Bug fix: Removes exception loop caused by `esc_html` in `_exception_handler()` [[421](https://github.com/pantheon-systems/wp-redis/pull/421)]

--- a/behat.yml
+++ b/behat.yml
@@ -3,10 +3,11 @@ default:
   suites:
     default:
       paths:
-        - tests/behat
+        - tests/behat/
       contexts:
         - Behat\MinkExtension\Context\MinkContext
         - PantheonSystems\PantheonWordPressUpstreamTests\Behat\AdminLogIn
+        - behat\features\bootstrap\WpRedisFeatureContext
   extensions:
     Behat\MinkExtension:
       # base_url set by ENV

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -30,9 +30,6 @@ set -ex
 terminus env:create  $TERMINUS_SITE.dev $TERMINUS_ENV
 terminus env:wipe $SITE_ENV --yes
 
-# Enable Redis
-terminus redis:enable $TERMINUS_SITE
-
 ###
 # Get all necessary environment details.
 ###

--- a/cli.php
+++ b/cli.php
@@ -41,7 +41,7 @@ class WP_Redis_CLI_Command {
 		$cmd = WP_CLI\Utils\esc_cmd( 'redis-cli -h %s -p %s -a %s -n %s', $redis_server['host'], $redis_server['port'], $redis_server['auth'], $redis_server['database'] );
 		$process = WP_CLI\Utils\proc_open_compat( $cmd, [ STDIN, STDOUT, STDERR ], $pipes );
 		$r = proc_close( $process );
-		exit( (int) $r );
+		exit( (int) $r ); // phpcs:ignore WordPressDotOrg.sniffs.OutputEscaping.UnescapedOutputParameter
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,9 @@
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true
     }
+  },
+  "autoload": {
+    "psr-4": { "behat\\features\\bootstrap\\": "tests/behat/features/bootstrap/" }
   }
+
 }

--- a/object-cache.php
+++ b/object-cache.php
@@ -1238,20 +1238,25 @@ class WP_Object_Cache {
 	 *               with defaults applied.
 	 */
 	public function build_client_parameters( $redis_server ) {
+		// Default Redis port.
+		$port = 6379;
+		// Default Redis database number.
+		$database = 0;
+
 		if ( empty( $redis_server ) ) {
 			// Attempt to automatically load Pantheon's Redis config from the env.
 			if ( isset( $_SERVER['CACHE_HOST'] ) ) {
 				$redis_server = [
 					'host' => wp_strip_all_tags( $_SERVER['CACHE_HOST'] ),
-					'port' => isset( $_SERVER['CACHE_PORT'] ) ? wp_strip_all_tags( $_SERVER['CACHE_PORT'] ) : 0,
-					'auth' => isset( $_SERVER['CACHE_PASSWORD'] ) ? wp_strip_all_tags( $_SERVER['CACHE_PASSWORD'] ) : '',
-					'database' => isset( $_SERVER['CACHE_DB'] ) ? wp_strip_all_tags( $_SERVER['CACHE_DB'] ) : 0,
+					'port' => isset( $_SERVER['CACHE_PORT'] ) ? wp_strip_all_tags( $_SERVER['CACHE_PORT'] ) : $port,
+					'auth' => isset( $_SERVER['CACHE_PASSWORD'] ) ? wp_strip_all_tags( $_SERVER['CACHE_PASSWORD'] ) : null,
+					'database' => isset( $_SERVER['CACHE_DB'] ) ? wp_strip_all_tags( $_SERVER['CACHE_DB'] ) : $database,
 				];
 			} else {
 				$redis_server = [
 					'host' => '127.0.0.1',
-					'port' => 6379,
-					'database' => 0,
+					'port' => $port,
+					'database' => $database,
 				];
 			}
 		}
@@ -1259,8 +1264,6 @@ class WP_Object_Cache {
 		if ( file_exists( $redis_server['host'] ) && 'socket' === filetype( $redis_server['host'] ) ) { // unix socket connection.
 			// port must be null or socket won't connect.
 			$port = null;
-		} else { // tcp connection.
-			$port = ! empty( $redis_server['port'] ) ? $redis_server['port'] : 6379;
 		}
 
 		$defaults = [
@@ -1470,9 +1473,9 @@ class WP_Object_Cache {
 		try {
 			$this->last_triggered_error = 'WP Redis: ' . $exception->getMessage();
 			// Be friendly to developers debugging production servers by triggering an error.
-			
+
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error,WordPress.Security.EscapeOutput.OutputNotEscaped
-			trigger_error( $this->last_triggered_error, E_USER_WARNING ); 
+			trigger_error( $this->last_triggered_error, E_USER_WARNING );
 		} catch ( PHPUnit_Framework_Error_Warning $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// PHPUnit throws an Exception when `trigger_error()` is called. To ensure our tests (which expect Exceptions to be caught) continue to run, we catch the PHPUnit exception and inspect the RedisException message.
 		}

--- a/object-cache.php
+++ b/object-cache.php
@@ -1247,10 +1247,14 @@ class WP_Object_Cache {
 			// Attempt to automatically load Pantheon's Redis config from the env.
 			if ( isset( $_SERVER['CACHE_HOST'] ) ) {
 				$redis_server = [
-					'host' => wp_strip_all_tags( $_SERVER['CACHE_HOST'] ),
-					'port' => isset( $_SERVER['CACHE_PORT'] ) ? wp_strip_all_tags( $_SERVER['CACHE_PORT'] ) : $port,
-					'auth' => isset( $_SERVER['CACHE_PASSWORD'] ) ? wp_strip_all_tags( $_SERVER['CACHE_PASSWORD'] ) : null,
-					'database' => isset( $_SERVER['CACHE_DB'] ) ? wp_strip_all_tags( $_SERVER['CACHE_DB'] ) : $database,
+					// Don't use WP methods to sanitize the host due to plugin loading issues with other caching methods.
+					// @phpcs:ignore WordPressVIPMinimum.Functions.StripTags.StripTagsOneParameter,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+					'host' => strip_tags( $_SERVER['CACHE_HOST'] ),
+					'port' => ! empty( $_SERVER['CACHE_PORT'] ) ? intval( $_SERVER['CACHE_PORT'] ) : $port,
+					// Don't attempt to sanitize passwords as this can break authentication.
+					// @phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+					'auth' => ! empty( $_SERVER['CACHE_PASSWORD'] ) ? $_SERVER['CACHE_PASSWORD'] : null,
+					'database' => ! empty( $_SERVER['CACHE_DB'] ) ? intval( $_SERVER['CACHE_DB'] ) : $database,
 				];
 			} else {
 				$redis_server = [
@@ -1263,9 +1267,8 @@ class WP_Object_Cache {
 
 		if ( file_exists( $redis_server['host'] ) && 'socket' === filetype( $redis_server['host'] ) ) { // unix socket connection.
 			// port must be null or socket won't connect.
+			unset( $redis_server['port'] );
 			$port = null;
-		} elseif ( ! empty( $redis_server['port'] ) ) { // tcp connection.
-			$port = $redis_server['port'];
 		}
 
 		$defaults = [
@@ -1277,7 +1280,7 @@ class WP_Object_Cache {
 		// 1s timeout, 100ms delay between reconnections.
 
 		// merging the defaults with the original $redis_server enables any custom parameters to get sent downstream to the redis client.
-		return array_replace_recursive( $redis_server, $defaults );
+		return array_replace_recursive( $defaults, $redis_server );
 	}
 
 	/**

--- a/object-cache.php
+++ b/object-cache.php
@@ -986,7 +986,7 @@ class WP_Object_Cache {
 			$out[] = '<li><strong>Group:</strong> ' . esc_html( $group ) . ' - ( ' . number_format( strlen( serialize( $cache ) ) / 1024, 2 ) . 'k )</li>';
 		}
 		$out[] = '</ul>';
-		echo implode( PHP_EOL, $out ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo implode( PHP_EOL, $out ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped,WordPressDotOrg.sniffs.OutputEscaping.UnescapedOutputParameter
 	}
 
 	/**

--- a/object-cache.php
+++ b/object-cache.php
@@ -1264,6 +1264,8 @@ class WP_Object_Cache {
 		if ( file_exists( $redis_server['host'] ) && 'socket' === filetype( $redis_server['host'] ) ) { // unix socket connection.
 			// port must be null or socket won't connect.
 			$port = null;
+		} elseif ( ! empty( $redis_server['port'] ) ) { // tcp connection.
+			$port = $redis_server['port'];
 		}
 
 		$defaults = [

--- a/readme.txt
+++ b/readme.txt
@@ -102,7 +102,8 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 
 == Changelog ==
 
-= Latest =
+= 1.4.3-dev =
+* Bug fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set. [[428](https://github.com/pantheon-systems/wp-redis/pull/428)] (props @tnolte)
 
 = 1.4.2 (May 15, 2023) =
 * Bug fix: Removes exception loop caused by `esc_html` in `_exception_handler()` [[421](https://github.com/pantheon-systems/wp-redis/pull/421)]

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon, danielbachhuber, mboynes, Outlandish Josh, jspellman,
 Tags: cache, plugin, redis
 Requires at least: 3.0.1
 Tested up to: 6.2
-Stable tag: 1.4.2
+Stable tag: 1.4.3-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,8 @@ This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `
 There's a known issue with WordPress `alloptions` cache design. Specifically, a race condition between two requests can cause the object cache to have stale values. If you think you might be impacted by this, [review this GitHub issue](https://github.com/pantheon-systems/wp-redis/issues/221) for links to more context, including a workaround.
 
 == Changelog ==
+
+= Latest =
 
 = 1.4.2 (May 15, 2023) =
 * Bug fix: Removes exception loop caused by `esc_html` in `_exception_handler()` [[421](https://github.com/pantheon-systems/wp-redis/pull/421)]

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,9 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 = 1.4.3-dev =
 * Bug fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set. [[428](https://github.com/pantheon-systems/wp-redis/pull/428)] (props @tnolte)
 * Adds WP.org validation GitHub action [[#435](https://github.com/pantheon-systems/wp-redis/pull/435)]
+* Bug fix: Fixes incorrect order of `array_replace_recursive` and other issues [[434](https://github.com/pantheon-systems/wp-redis/pull/434)] (props @timnolte)
+* Bug fix: Replace use of wp_strip_all_tags in object-cache.php [[434](https://github.com/pantheon-systems/wp-redis/pull/434)] (props @timnolte)
+* Bug fix: Don't strip tags from the cache password. [[434](https://github.com/pantheon-systems/wp-redis/pull/434)] (props @timnolte)
 
 = 1.4.2 (May 15, 2023) =
 * Bug fix: Removes exception loop caused by `esc_html` in `_exception_handler()` [[421](https://github.com/pantheon-systems/wp-redis/pull/421)]

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 
 = 1.4.3-dev =
 * Bug fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set. [[428](https://github.com/pantheon-systems/wp-redis/pull/428)] (props @tnolte)
+* Adds WP.org validation GitHub action [[#435](https://github.com/pantheon-systems/wp-redis/pull/435)]
 
 = 1.4.2 (May 15, 2023) =
 * Bug fix: Removes exception loop caused by `esc_html` in `_exception_handler()` [[421](https://github.com/pantheon-systems/wp-redis/pull/421)]

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon, danielbachhuber, mboynes, Outlandish Josh, jspellman,
 Tags: cache, plugin, redis
 Requires at least: 3.0.1
 Tested up to: 6.2
-Stable tag: 1.4.3-dev
+Stable tag: 1.4.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -102,7 +102,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 
 == Changelog ==
 
-= 1.4.3-dev =
+= 1.4.3 (June 26, 2023)  =
 * Bug fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set. [[428](https://github.com/pantheon-systems/wp-redis/pull/428)] (props @tnolte)
 * Adds WP.org validation GitHub action [[#435](https://github.com/pantheon-systems/wp-redis/pull/435)]
 * Bug fix: Fixes incorrect order of `array_replace_recursive` and other issues [[434](https://github.com/pantheon-systems/wp-redis/pull/434)] (props @timnolte)

--- a/tests/behat/features/bootstrap/WpRedisFeatureContext.php
+++ b/tests/behat/features/bootstrap/WpRedisFeatureContext.php
@@ -1,0 +1,35 @@
+<?php
+// features/bootstrap/WPRedisFeatureContext.php
+
+namespace behat\features\bootstrap;
+
+use Behat\Behat\Context\Context;
+
+class WpRedisFeatureContext implements Context
+{
+
+    /**
+     * Initializes context.
+     *
+     * Every scenario gets its own context instance.
+     * You can also pass arbitrary arguments to the
+     * context constructor through behat.yml.
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Waits a certain number of seconds.
+     *
+     * @param int $seconds
+     *   How long to wait.
+     *
+     * @When I wait :seconds second(s)
+     */
+    public function wait($seconds)
+    {
+        sleep($seconds);
+    }
+
+}

--- a/tests/behat/load-wp.feature
+++ b/tests/behat/load-wp.feature
@@ -22,6 +22,7 @@ Feature: Load WordPress
     When I go to "/wp-admin/options-general.php"
     And I fill in "blogname" with "Pantheon WordPress Site"
     And I press "submit"
+    When I wait "1" second
     Then print current URL
     And I should see "Settings saved."
 

--- a/tests/behat/wp-redis.feature
+++ b/tests/behat/wp-redis.feature
@@ -15,4 +15,10 @@ Feature: WP Redis
     Then I should see "Redis Calls:"
     And I should see "Cache Hits:"
     And I should see "Cache Misses:"
-    And I should see "- get:"
+    And I should see "Redis Calls:"
+
+    # We call the same page twice to give Redis an opportunity to cache
+    # something so that `get` actually fires.
+    When I am on "/?redis_debug"
+    Then I should see "Group:"
+    Then I should see "- get"

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -38,12 +38,12 @@ function wp_redis_get_info() {
 
 	if ( empty( $redis_server ) ) {
 		// Attempt to automatically load Pantheon's Redis config from the env.
-		if ( isset( $_SERVER['CACHE_HOST'] ) && isset( $_SERVER['CACHE_PORT'] ) && isset( $_SERVER['CACHE_PASSWORD'] ) && isset( $_SERVER['CACHE_DB'] ) ) {
+		if ( isset( $_SERVER['CACHE_HOST'] ) ) {
 			$redis_server = [
 				'host' => sanitize_text_field( $_SERVER['CACHE_HOST'] ),
-				'port' => sanitize_text_field( $_SERVER['CACHE_PORT'] ),
-				'auth' => sanitize_text_field( $_SERVER['CACHE_PASSWORD'] ),
-				'database' => sanitize_text_field( $_SERVER['CACHE_DB'] ),
+				'port' => isset( $_SERVER['CACHE_PORT'] ) ? sanitize_text_field( $_SERVER['CACHE_PORT'] ) : 6379,
+				'auth' => isset( $_SERVER['CACHE_PASSWORD'] ) ? sanitize_text_field( $_SERVER['CACHE_PASSWORD'] ) : null,
+				'database' => isset( $_SERVER['CACHE_DB'] ) ? sanitize_text_field( $_SERVER['CACHE_DB'] ) : 0,
 			];
 		} else {
 			$redis_server = [

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Redis
  * Plugin URI: http://github.com/pantheon-systems/wp-redis/
  * Description: WordPress Object Cache using Redis. Requires the PhpRedis extension (https://github.com/phpredis/phpredis).
- * Version: 1.4.2
+ * Version: 1.4.3-dev
  * Author: Pantheon, Josh Koenig, Matthew Boynes, Daniel Bachhuber, Alley Interactive
  * Author URI: https://pantheon.io/
  */

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Redis
  * Plugin URI: http://github.com/pantheon-systems/wp-redis/
  * Description: WordPress Object Cache using Redis. Requires the PhpRedis extension (https://github.com/phpredis/phpredis).
- * Version: 1.4.3-dev
+ * Version: 1.4.3
  * Author: Pantheon, Josh Koenig, Matthew Boynes, Daniel Bachhuber, Alley Interactive
  * Author URI: https://pantheon.io/
  */


### PR DESCRIPTION
**Hold for release until Monday, June 26.**

## Release Notes
* Bug fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set. [[428](https://github.com/pantheon-systems/wp-redis/pull/428)] (props @timnolte)
* Adds WP.org validation GitHub action [[#435](https://github.com/pantheon-systems/wp-redis/pull/435)]
* Bug fix: Fixes incorrect order of `array_replace_recursive` and other issues [[434](https://github.com/pantheon-systems/wp-redis/pull/434)] (props @timnolte)
* Bug fix: Replace use of wp_strip_all_tags in object-cache.php [[434](https://github.com/pantheon-systems/wp-redis/pull/434)] (props @timnolte)
* Bug fix: Don't strip tags from the cache password. [[434](https://github.com/pantheon-systems/wp-redis/pull/434)] (props @timnolte)