### PR TITLE
Update CONTRIBUTING docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ The behat tests require a Pantheon site with Redis enabled. Once you've created 
     * Commit these changes with the message `Release X.Y.Z`
     * Push the release branch up.
 1. Open a Pull Request to merge `release_X.Y.Z` into `release`. Your PR should consist of all commits to `main` since the last release, and one commit to update the version number. The PR name should also be `Release X.Y.Z`.
-1. After all tests pass and you have received approval from a [CODEOWNER](./CODEOWNERS), merge the PR into `release`. "Rebase and merge" is preferred in this case. _Never_ squash to `release`.
+1. After all tests pass and you have received approval from a [CODEOWNER](./CODEOWNERS), merge the PR into `release`. A merge commit is preferred in this case. _Never_ squash to `release`.
 1. Locally, pull the `release` branch, create a new tag (based on version number from previous steps), and push up. The tag should _only_ be the version number. It _should not_ be prefixed  `v` (i.e. `X.Y.Z`, not `vX.Y.X`).
     * `git tag X.Y.Z`
     * `git push --tags`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,11 @@ Pull requests and issues are welcome!
 
 ## Workflow
 
-Development and releases are structured around two branches, `default` and `release`. The `default` branch is the default branch for the repository, and is the source and destination for feature branches.
+Development and releases are structured around two branches, `main` and `release`. The `main` branch is the default branch for the repository, and is the source and destination for feature branches.
 
-We prefer to squash commits (i.e. avoid merge PRs) from a feature branch into `default` when merging, and to include the PR # in the commit message. PRs to `default` should also include any relevent updates to the changelog in readme.txt. For example, if a feature constitutes a minor or major version bump, that version update should be discussed and made as part of approving and merging the feature into `default`.
+We prefer to squash commits (i.e. avoid merge PRs) from a feature branch into `main` when merging, and to include the PR # in the commit message. PRs to `main` should also include any relevent updates to the changelog in readme.txt. For example, if a feature constitutes a minor or major version bump, that version update should be discussed and made as part of approving and merging the feature into `main`.
 
-`default` should be stable and usable, though possibly a few commits ahead of the public release on wp.org.
+`main` should be stable and usable, though possibly a few commits ahead of the public release on wp.org.
 
 The `release` branch matches the latest stable release deployed to [wp.org](https://wordpress.org/).
 
@@ -31,13 +31,13 @@ The behat tests require a Pantheon site with Redis enabled. Once you've created 
 
 ## Release Process
 
-1. From `default`, checkout a new branch `release_X.Y.Z`.
+1. From `main`, checkout a new branch `release_X.Y.Z`.
 1. Make a release commit:
     * In `README.md`, `readme.txt`, and `wp-redis.php`, remove the `-dev` from the version number. For the README files. the version number must be updated both at the top of the document as well as the changelog.
     * Add the date to the `** X.Y.X **` heading in the changelogs in README.md, readme.txt, and any other appropriate location.
     * Commit these changes with the message `Release X.Y.Z`
     * Push the release branch up.
-1. Open a Pull Request to merge `release_X.Y.Z` into `release`. Your PR should consist of all commits to `default` since the last release, and one commit to update the version number. The PR name should also be `Release X.Y.Z`.
+1. Open a Pull Request to merge `release_X.Y.Z` into `release`. Your PR should consist of all commits to `main` since the last release, and one commit to update the version number. The PR name should also be `Release X.Y.Z`.
 1. After all tests pass and you have received approval from a [CODEOWNER](./CODEOWNERS), merge the PR into `release`. "Rebase and merge" is preferred in this case. _Never_ squash to `release`.
 1. Locally, pull the `release` branch, create a new tag (based on version number from previous steps), and push up. The tag should _only_ be the version number. It _should not_ be prefixed  `v` (i.e. `X.Y.Z`, not `vX.Y.X`).
     * `git tag X.Y.Z`
@@ -49,10 +49,10 @@ The behat tests require a Pantheon site with Redis enabled. Once you've created 
 1. Following the release, prepare the next dev version with the following steps:
     * `git checkout release`
     * `git pull origin release`
-    * `git checkout default`
+    * `git checkout main`
     * `git rebase release`
     * Update the version number in all locations, incrementing the version by one patch version, and add the `-dev` flag (e.g. after releasing `1.2.3`, the new verison will be `1.2.4-dev`)
     * Add a new `** X.Y.X-dev **` heading to the changelog
     * `git add -A .`
     * `git commit -m "Prepare X.Y.X-dev"`
-    * `git push origin default`
+    * `git push origin main`


### PR DESCRIPTION
Replaces `default` with `main` and adds note to create a merge commit for the release PR rather than rebase.