### PR TITLE
Fix spacing of README.md header and add linting to ensure it remains.

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: pantheon-systems/validate-readme-spacing@v1.0.1
+      - uses: pantheon-systems/validate-readme-spacing@v1.0.2
   wporg-validation:
     name: WP.org Validator
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: pantheon-systems/validate-readme-spacing@v1
+      - uses: pantheon-systems/validate-readme-spacing@v1.0.1
   wporg-validation:
     name: WP.org Validator
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,8 +1,16 @@
 # On push, run the action-wporg-validator workflow.
-name: WP.org Validator
+name: Linting & Test
 on: [push]
 jobs:
+  validate-readme-spacing:
+    name: Validate README Spacing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: pantheon-systems/validate-readme-spacing@v1
   wporg-validation:
+    name: WP.org Validator
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: pantheon-systems/validate-readme-spacing@v1.0.2
+      - uses: pantheon-systems/validate-readme-spacing@v1
   wporg-validation:
     name: WP.org Validator
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # WP Redis #
 [![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#actively-maintained)
 
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [mboynes](https://profiles.wordpress.org/mboynes), [Outlandish Josh](https://profiles.wordpress.org/outlandish-josh) [jspellman](https://profiles.wordpress.org/jspellman/) [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/)
-**Tags:** cache, plugin, redis
-**Requires at least:** 3.0.1
-**Tested up to:** 6.2
-**Stable tag:** 1.4.4-dev
-**License:** GPLv2 or later
-**License URI:** http://www.gnu.org/licenses/gpl-2.0.html
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [mboynes](https://profiles.wordpress.org/mboynes), [Outlandish Josh](https://profiles.wordpress.org/outlandish-josh) [jspellman](https://profiles.wordpress.org/jspellman/) [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/)  
+**Tags:** cache, plugin, redis  
+**Requires at least:** 3.0.1  
+**Tested up to:** 6.2  
+**Stable tag:** 1.4.4-dev  
+**License:** GPLv2 or later  
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
 Back your WP Object Cache with Redis, a high-performance in-memory storage backend.
 


### PR DESCRIPTION
Two trailing spaces are required for single line breaks to appear in Markdown's rendered view.
Adds github action to check for invalid spacing of the Plugin's README header.