### PR TITLE
[BUGS-7148] Handle duplicate keys in `get_multiple` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # WP Redis #
 [![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#actively-maintained)
 
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [mboynes](https://profiles.wordpress.org/mboynes), [Outlandish Josh](https://profiles.wordpress.org/outlandish-josh) [jspellman](https://profiles.wordpress.org/jspellman/) [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/)
-**Tags:** cache, plugin, redis
-**Requires at least:** 3.0.1
-**Tested up to:** 6.4.1
-**Stable tag:** 1.4.4-dev
-**License:** GPLv2 or later
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [mboynes](https://profiles.wordpress.org/mboynes), [Outlandish Josh](https://profiles.wordpress.org/outlandish-josh) [jspellman](https://profiles.wordpress.org/jspellman/) [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/)  
+**Tags:** cache, plugin, redis  
+**Requires at least:** 3.0.1  
+**Tested up to:** 6.4.1  
+**Stable tag:** 1.4.4-dev  
+**License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 Back your WP Object Cache with Redis, a high-performance in-memory storage backend.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # WP Redis #
 [![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#actively-maintained)
 
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [mboynes](https://profiles.wordpress.org/mboynes), [Outlandish Josh](https://profiles.wordpress.org/outlandish-josh) [jspellman](https://profiles.wordpress.org/jspellman/) [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/)  
-**Tags:** cache, plugin, redis  
-**Requires at least:** 3.0.1  
-**Tested up to:** 6.4.1  
-**Stable tag:** 1.4.4-dev  
-**License:** GPLv2 or later  
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [mboynes](https://profiles.wordpress.org/mboynes), [Outlandish Josh](https://profiles.wordpress.org/outlandish-josh) [jspellman](https://profiles.wordpress.org/jspellman/) [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/)
+**Tags:** cache, plugin, redis
+**Requires at least:** 3.0.1
+**Tested up to:** 6.4.1
+**Stable tag:** 1.4.4-dev
+**License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 Back your WP Object Cache with Redis, a high-performance in-memory storage backend.
@@ -111,6 +111,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 ### 1.4.4-dev ###
 * Updates security policy [[#441](https://github.com/pantheon-systems/wp-redis/pull/441)]
 * Updates Pantheon WP Coding Standards to 2.0 [[#445](https://github.com/pantheon-systems/wp-redis/pull/445)]
+* Handle duplicate keys in `get_multiple` function [[#448](https://github.com/pantheon-systems/wp-redis/pull/448)] (props @Souptik2001)
 
 ### 1.4.3 (June 26, 2023) ###
 * Bug fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set. [[428](https://github.com/pantheon-systems/wp-redis/pull/428)] (props @timnolte)

--- a/object-cache.php
+++ b/object-cache.php
@@ -759,6 +759,9 @@ class WP_Object_Cache {
 			$group = 'default';
 		}
 
+		// Get unique keys.
+		$keys = array_unique( $keys );
+
 		$cache = [];
 		if ( ! $this->_should_persist( $group ) ) {
 			foreach ( $keys as $key ) {

--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,7 @@ Please report security bugs found in the source code of the WP Redis plugin thro
 = 1.4.4-dev =
 * Updates security policy [[#441](https://github.com/pantheon-systems/wp-redis/pull/441)]
 * Updates Pantheon WP Coding Standards to 2.0 [[#445](https://github.com/pantheon-systems/wp-redis/pull/445)]
+* Handle duplicate keys in `get_multiple` function [[#448](https://github.com/pantheon-systems/wp-redis/pull/448)] (props @souptik)
 
 = 1.4.3 (June 26, 2023)  =
 * Bug fix: Fixes assumption that CACHE_PORT & CACHE_PASSWORD are Set. [[428](https://github.com/pantheon-systems/wp-redis/pull/428)] (props @tnolte)

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -855,6 +855,31 @@ class CacheTest extends WP_UnitTestCase {
 		} else {
 			$this->assertEmpty( $this->cache->redis_calls );
 		}
+
+		$this->cache->set( 'foo3', 'bar1', 'group1' );
+		$this->cache->set( 'foo4', 'bar2', 'group1' );
+
+		$found = $this->cache->get_multiple( [ 'foo3', 'foo3', 'foo4' ], 'group1', true );
+
+		$expected = [
+			'foo3' => 'bar1',
+			'foo4' => 'bar2',
+		];
+
+		$this->assertSame( $expected, $found );
+		$this->assertEquals( 4, $this->cache->cache_hits );
+		$this->assertEquals( 1, $this->cache->cache_misses );
+		if ( $this->cache->is_redis_connected ) {
+			$this->assertEquals(
+				[
+					self::$mget_key => 2,
+					self::$set_key  => 5,
+				],
+				$this->cache->redis_calls
+			);
+		} else {
+			$this->assertEmpty( $this->cache->redis_calls );
+		}
 	}
 
 	public function test_get_multiple_partial_cache_miss() {


### PR DESCRIPTION
Hi :wave: ,
Seems like the `WP_Object_Cache:get_multiple` function breaks when we pass duplicate keys in the `$keys` array argument.

When any duplicate key is passed in the array all the values of the keys coming after that duplicate gets messed up. Basically they gets shifted by one after a duplicate. Again after another duplicate is there the values after that second duplicate gets shifted by two, and similarly.

This basically happens due to the way we get the cache values from the two arrays - `$remaining_keys` and `$results`. In the results array we don't get the value twice, we just get once. But we iterate through all the `$remaining_keys` and just access the corresponding index of the `$results` array. That's why this is happening.

So, the easiest solution for this would be to just fetch the unique values in the beginning of the function only. This will not only fix the bug, but also reduce the minor redundant extra computations of the duplicate keys.

I have also added a test case, which will break if you run it by removing the fix from the `object-cache.php`.

I think this edge case should be handled here, because this function doesn't deny you to pass duplicate keys, but also doesn't handle duplicate keys.

Thanks! Please let me know if any other info is needed. :slightly_smiling_face: 