### PR TITLE
[CMSP-721] Bump tested up to and echo PHP Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [mboynes](https://profiles.wordpress.org/mboynes), [Outlandish Josh](https://profiles.wordpress.org/outlandish-josh) [jspellman](https://profiles.wordpress.org/jspellman/) [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/)  
 **Tags:** cache, plugin, redis  
 **Requires at least:** 3.0.1  
-**Tested up to:** 6.3  
+**Tested up to:** 6.4.1  
 **Stable tag:** 1.4.4-dev  
 **License:** GPLv2 or later  
-**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 Back your WP Object Cache with Redis, a high-performance in-memory storage backend.
 

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -55,7 +55,7 @@ rsync -av --exclude='vendor/' --exclude='node_modules/' --exclude='tests/' ./* $
 rm -rf $PREPARE_DIR/wp-content/plugins/wp-redis/.git
 cp object-cache.php $PREPARE_DIR/wp-content/object-cache.php
 
-PHP_VERSION="$(terminus site:info $SITE_ENV --field=php_version)"
+PHP_VERSION="$(terminus env:info $SITE_ENV --field=php_version)"
 echo "PHP Version: $PHP_VERSION"
 
 ###

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -55,6 +55,9 @@ rsync -av --exclude='vendor/' --exclude='node_modules/' --exclude='tests/' ./* $
 rm -rf $PREPARE_DIR/wp-content/plugins/wp-redis/.git
 cp object-cache.php $PREPARE_DIR/wp-content/object-cache.php
 
+PHP_VERSION="$(terminus site:info $SITE_ENV --field=php_version)"
+echo "PHP Version: $PHP_VERSION"
+
 ###
 # Add the debugging plugin to the environment
 ###

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, mboynes, Outlandish Josh, jspellman, jazzs3quence
 Tags: cache, plugin, redis
 Requires at least: 3.0.1
-Tested up to: 6.3
+Tested up to: 6.4.1
 Stable tag: 1.4.4-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
So we can ensure that the Behat tests are running on PHP 8.3.

These tests should pass because New Relic is not active on the CI fixture site.