### PR TITLE
Change default branch for dependabot to "main"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     interval: weekly
     timezone: America/Los_Angeles
     day: tuesday
-  target-branch: "default"
+  target-branch: "main"
   open-pull-requests-limit: 99
   ignore:
   - dependency-name: phpunit/phpunit


### PR DESCRIPTION
Default was left behind from a previous implementation.