### PR TITLE
[SITE-2632] Update check_client_dependencies to check for Relay

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -1226,7 +1226,7 @@ class WP_Object_Cache {
 	 *               not with a message describing the issue.
 	 */
 	public function check_client_dependencies() {
-		if ( ! class_exists( 'Redis' ) ) {
+		if ( ! class_exists( WP_REDIS_USE_RELAY ? 'Relay\Relay' : 'Redis' ) ) {
 			return 'Warning! PHPRedis extension is unavailable, which is required by WP Redis object cache.';
 		}
 		return true;

--- a/object-cache.php
+++ b/object-cache.php
@@ -1226,7 +1226,8 @@ class WP_Object_Cache {
 	 *               not with a message describing the issue.
 	 */
 	public function check_client_dependencies() {
-		if ( ! class_exists( WP_REDIS_USE_RELAY ? 'Relay\Relay' : 'Redis' ) ) {
+		$has_relay = defined( 'WP_REDIS_USE_RELAY' ) && class_exists( 'Relay\Relay' );
+		if ( ! $has_relay || ! class_exists( 'Redis' ) ) {
 			return 'Warning! PHPRedis extension is unavailable, which is required by WP Redis object cache.';
 		}
 		return true;


### PR DESCRIPTION
This PR fixes 2 cases where `WP_REDIS_USE_RELAY=true`

- The class is not checked for existence.
- The drop-in will not run if Redis extension is not installed.

The fix:

- Relay\Relay is correctly checked for existence.
- The drop-in still works if the Redis extension is not installed.