### PR TITLE
Install SVN if needed

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -91,6 +91,13 @@ jobs:
             composer update
           fi
           composer install
+      - name: Install SVN if needed
+        run: |
+          if ! command -v svn &> /dev/null; then
+            echo "SVN is not installed. Installing now..."
+            sudo apt-get update
+            sudo apt-get install -y subversion
+          fi
       - name: Run PHPUnit
         run: |
           if [ ${{ matrix.redis_enabled }} = 'true' ]; then


### PR DESCRIPTION
SVN is installed [on Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) but not [24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md).

We will eventually need to do this for all projects or fold into the helpers.sh project