### PR TITLE
[SITE-2845] Setup jazzsequence/action-validate-plugin-version

### DIFF
--- a/.github/workflows/plugin-version.yml
+++ b/.github/workflows/plugin-version.yml
@@ -1,0 +1,19 @@
+name: Validate "Tested Up To"
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  contents: write
+  pull-requests: write
+  
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Validate Plugin Version
+        uses: jazzsequence/action-validate-plugin-version@v1.2.4


### PR DESCRIPTION
Configured against the development (main) branch at the moment, will move to release if/when we setup asset-only updates.