### PR TITLE
use v1 branch of validate-plugin-version

### DIFF
--- a/.github/workflows/plugin-version.yml
+++ b/.github/workflows/plugin-version.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -16,4 +16,4 @@ jobs:
         with:
           fetch-depth: 0
       - name: Validate Plugin Version
-        uses: jazzsequence/action-validate-plugin-version@v1.2.4
+        uses: jazzsequence/action-validate-plugin-version@v1


### PR DESCRIPTION
v1 opens PRs in draft status, see https://github.com/jazzsequence/action-validate-plugin-version/pull/15