### PR TITLE
Release 1.4.6

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: [7.4, 8.2, 8.3]
+        php_version: [7.4, 8.2, 8.3, 8.4]
         redis_enabled: [true, false]
     services:
       mariadb:

--- a/.github/workflows/plugin-version.yml
+++ b/.github/workflows/plugin-version.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           fetch-depth: 0
       - name: Validate Plugin Version
-        uses: jazzsequence/action-validate-plugin-version@v1.2.4
+        uses: jazzsequence/action-validate-plugin-version@v1.2.6

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [mboynes](https://profiles.wordpress.org/mboynes), [Outlandish Josh](https://profiles.wordpress.org/outlandish-josh) [jspellman](https://profiles.wordpress.org/jspellman/) [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/)  
 **Tags:** cache, plugin, redis  
 **Requires at least:** 3.0.1  
-**Tested up to:** 6.7.1  
+**Tested up to:** 6.8.1  
 **Stable tag:** 1.4.6-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Requires at least:** 3.0.1  
 **Tested up to:** 6.8.1  
 **Requires PHP:** 7.4  
-**Stable tag:** 1.4.6-dev  
+**Stable tag:** 1.4.6  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -109,7 +109,8 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 
 ## Changelog ##
 
-### 1.4.6 ###
+### 1.4.6 (June 17, 2025) ###
+* PHP 8.4 compatibility
 
 ### 1.4.5 (January 21, 2024) ###
 * Support Relay in `check_client_dependencies()` correctly [[#471](https://github.com/pantheon-systems/wp-redis/pull/471)] (props @EarthlingDavey)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Tags:** cache, plugin, redis  
 **Requires at least:** 3.0.1  
 **Tested up to:** 6.7.1  
-**Stable tag:** 1.4.5  
+**Stable tag:** 1.4.6-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -107,6 +107,8 @@ This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `
 There's a known issue with WordPress `alloptions` cache design. Specifically, a race condition between two requests can cause the object cache to have stale values. If you think you might be impacted by this, [review this GitHub issue](https://github.com/pantheon-systems/wp-redis/issues/221) for links to more context, including a workaround.
 
 ## Changelog ##
+
+### 1.4.6 ###
 
 ### 1.4.5 (January 21, 2024) ###
 * Support Relay in `check_client_dependencies()` correctly [[#471](https://github.com/pantheon-systems/wp-redis/pull/471)] (props @EarthlingDavey)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This assumes you have a PHP environment with the [required PhpRedis extension](h
         $redis_server = array(
             'host'     => '127.0.0.1',
             'port'     => 6379,
-            'auth'     => '12345',
+            'auth'     => '12345', // ['user', 'password'] if you use Redis ACL
             'database' => 0, // Optionally use a specific numeric Redis database. Default is 0.
         );
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 **Tags:** cache, plugin, redis  
 **Requires at least:** 3.0.1  
 **Tested up to:** 6.8.1  
+**Requires PHP:** 7.4  
 **Stable tag:** 1.4.6-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "pantheon-systems/pantheon-wp-coding-standards": "^2.0",
     "pantheon-systems/pantheon-wordpress-upstream-tests": "dev-master",
     "phpunit/phpunit": "^9",
-    "yoast/phpunit-polyfills": "^3.0",
+    "yoast/phpunit-polyfills": "^4.0",
     "pantheon-systems/wpunit-helpers": "^2.0"
   },
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8399bd0366951ba0afa363bee128ae8",
+    "content-hash": "1ec03a587fe10d4013cb9dcc3665d2ef",
     "packages": [],
     "packages-dev": [
         {
@@ -5703,21 +5703,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "e6381c62c4df51677b657fbac79b79dfce7acdab"
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/e6381c62c4df51677b657fbac79b79dfce7acdab",
-                "reference": "e6381c62c4df51677b657fbac79b79dfce7acdab",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -5727,7 +5727,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.x-dev"
+                    "dev-main": "4.x-dev"
                 }
             },
             "autoload": {
@@ -5762,7 +5762,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-01-12T08:41:37+00:00"
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon, danielbachhuber, mboynes, Outlandish Josh, jspellman,
 Tags: cache, plugin, redis
 Requires at least: 3.0.1
 Tested up to: 6.7.1
-Stable tag: 1.4.5
+Stable tag: 1.4.6-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -104,6 +104,8 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 Please report security bugs found in the source code of the WP Redis plugin through the [Patchstack Vulnerability Disclosure Program](https://patchstack.com/database/vdp/wp-redis). The Patchstack team will assist you with verification, CVE assignment, and notify the developers of this plugin.
 
 == Changelog ==
+
+= 1.4.6-dev =
 
 = 1.4.5 (January 21, 2024) =
 * Support Relay in check_client_dependencies() with the WP_REDIS_USE_RELAY constant [[#471](https://github.com/pantheon-systems/wp-redis/pull/471)]

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, mboynes, Outlandish Josh, jspellman, jazzs3quence
 Tags: cache, plugin, redis
 Requires at least: 3.0.1
-Tested up to: 6.7.2
+Tested up to: 6.8.1
 Stable tag: 1.4.6-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: cache, plugin, redis
 Requires at least: 3.0.1
 Tested up to: 6.8.1
 Requires PHP: 7.4
-Stable tag: 1.4.6-dev
+Stable tag: 1.4.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -106,7 +106,8 @@ Please report security bugs found in the source code of the WP Redis plugin thro
 
 == Changelog ==
 
-= 1.4.6-dev =
+= 1.4.6 (June 17, 2025) =
+* PHP 8.4 compatibility 
 
 = 1.4.5 (January 21, 2024) =
 * Support Relay in check_client_dependencies() with the WP_REDIS_USE_RELAY constant [[#471](https://github.com/pantheon-systems/wp-redis/pull/471)]

--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@ Contributors: getpantheon, danielbachhuber, mboynes, Outlandish Josh, jspellman,
 Tags: cache, plugin, redis
 Requires at least: 3.0.1
 Tested up to: 6.8.1
+Requires PHP: 7.4
 Stable tag: 1.4.6-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -31,11 +31,11 @@ This assumes you have a PHP environment with the [required PhpRedis extension](h
         $redis_server = array(
             'host'     => '127.0.0.1',
             'port'     => 6379,
-            'auth'     => '12345',
+            'auth'     => '12345', // ['user', 'password'] if you use Redis ACL
             'database' => 0, // Optionally use a specific numeric Redis database. Default is 0.
         );
 
-3. If your Redis server is listening through a sockt file instead, set its path on `host` parameter and change the port to `null`:
+3. If your Redis server is listening through a socket file instead, set its path on `host` parameter and change the port to `null`:
 
         $redis_server = array(
             'host'     => '/path/of/redis/socket-file.sock',

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, mboynes, Outlandish Josh, jspellman, jazzs3quence
 Tags: cache, plugin, redis
 Requires at least: 3.0.1
-Tested up to: 6.7.1
+Tested up to: 6.7.2
 Stable tag: 1.4.6-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Redis
  * Plugin URI: http://github.com/pantheon-systems/wp-redis/
  * Description: WordPress Object Cache using Redis. Requires the PhpRedis extension (https://github.com/phpredis/phpredis).
- * Version: 1.4.6-dev
+ * Version: 1.4.6
  * Author: Pantheon, Josh Koenig, Matthew Boynes, Daniel Bachhuber, Alley Interactive
  * Author URI: https://pantheon.io/
  */

--- a/wp-redis.php
+++ b/wp-redis.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Redis
  * Plugin URI: http://github.com/pantheon-systems/wp-redis/
  * Description: WordPress Object Cache using Redis. Requires the PhpRedis extension (https://github.com/phpredis/phpredis).
- * Version: 1.4.5
+ * Version: 1.4.6-dev
  * Author: Pantheon, Josh Koenig, Matthew Boynes, Daniel Bachhuber, Alley Interactive
  * Author URI: https://pantheon.io/
  */


### PR DESCRIPTION
- Add support for PHP 8.4 Compatibility
- Bump tested upto version to 6.8.1

-  Bump yoast/phpunit-polyfills from 3.1.1 to 4.0.0

- Add Redis ACL instructions to README
- Bump jazzsequence/action-validate-plugin-version from 1.2.4 to 1.2.6