### PR TITLE
Remove duplicate wp.org validator from lint-test workflow

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -29,16 +29,6 @@ jobs:
       run: composer install -n --prefer-dist
     - name: Run PHP Lint
       run: composer phpcs
-  wporg-validation:
-    name: WP.org Validator
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - name: WP.org Validator
-        uses: pantheon-systems/action-wporg-validator@v2.0.0
-        with:
-          type: plugin
   php8-compatibility:
     name: PHP 8.x Compatibility
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Removes the duplicate wp.org validator job from the lint-test workflow

Tests failing due to #518, can just merge, or wait til that is merged and rebase.