### PR TITLE
[SITE-5206] Add PHP 8.5 compatibility

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: [7.4, 8.2, 8.3, 8.4]
+        php_version: [7.4, 8.2, 8.3, 8.4, 8.5]
         redis_enabled: [true, false]
     services:
       mariadb:

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 ## Changelog ##
 
 ### 1.4.8-dev ###
+* PHP 8.5 compatibility
 
 ### 1.4.7 (December 2, 2025) ###
 * WordPress 6.9 compatibility [[#524](https://github.com/pantheon-systems/wp-redis/pull/524)]

--- a/object-cache.php
+++ b/object-cache.php
@@ -444,6 +444,20 @@ class WP_Object_Cache {
 	public $last_triggered_error = '';
 
 	/**
+	 * The Redis client instance
+	 *
+	 * @var Redis|Relay\Relay
+	 */
+	public $redis;
+
+	/**
+	 * Message describing why Redis is unavailable
+	 *
+	 * @var string
+	 */
+	public $missing_redis_message = '';
+
+	/**
 	 * Whether or not to use true cache groups, instead of flattening.
 	 *
 	 * @var bool


### PR DESCRIPTION
## Summary
- Added PHP 8.5 to the GitHub Actions test matrix to ensure compatibility
- Updated changelog to reflect PHP 8.5 support

## Test plan
- GitHub Actions will automatically run the full test suite against PHP 8.5 (with both Redis enabled and disabled)
- Verify all tests pass with PHP 8.5
- Ensure backward compatibility is maintained for PHP 7.4, 8.2, 8.3, and 8.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)