### PR TITLE
[SITE-5206] Add PHP 8.5 compatibility

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: [7.4, 8.2, 8.3, 8.4]
+        php_version: [7.4, 8.2, 8.3, 8.4, 8.5]
         redis_enabled: [true, false]
     services:
       mariadb:

--- a/.github/workflows/test-behat.yml
+++ b/.github/workflows/test-behat.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install SSH key
         uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
-          ssh-private-key: ${{ secrets.SITE_OWNER_SSH_PRIVATE_KEY }}
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       # Configures Composer with the GitHub token for accessing private repositories.
       # The GITHUB_TOKEN is automatically provided by GitHub Actions.

--- a/.github/workflows/test-behat.yml
+++ b/.github/workflows/test-behat.yml
@@ -48,8 +48,8 @@ jobs:
           ENV_NAME="ci-$(echo ${{ github.run_id }} | cut -c1-8)"
           echo "WORDPRESS_ADMIN_PASSWORD=$(openssl rand -hex 8)" >> $GITHUB_ENV
           echo "TERMINUS_ENV=${ENV_NAME}" >> $GITHUB_ENV
-          echo "TERMINUS_SITE=wp-redis" >> $GITHUB_ENV
-          echo "SITE_ENV=wp-redis.${ENV_NAME}" >> $GITHUB_ENV
+          echo "TERMINUS_SITE=${{ vars.TERMINUS_SITE }}" >> $GITHUB_ENV
+          echo "SITE_ENV=${{ vars.TERMINUS_SITE }}.${ENV_NAME}" >> $GITHUB_ENV
           echo "WORDPRESS_ADMIN_USERNAME=pantheon" >> $GITHUB_ENV
           echo "WORDPRESS_ADMIN_EMAIL=no-reply@getpantheon.com" >> $GITHUB_ENV
 

--- a/.github/workflows/wporg-validator.yml
+++ b/.github/workflows/wporg-validator.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         php-version: "8.4"
         extensions: mysqli
-        tools: composer:2.8,wp-cli
+        tools: composer,wp-cli
 
     - name: Cache Composer dependencies
       uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
@@ -38,7 +38,7 @@ jobs:
 
     - name: Create Dist Archive for wp.org validation
       run: |
-        wp package install wp-cli/dist-archive-command:v3.1.0
+        wp package install wp-cli/dist-archive-command
         wp dist-archive . --plugin-dirname=wp-redis --filename-format=wp-redis-dist
         unzip ../wp-redis-dist.zip
 

--- a/.github/workflows/wporg-validator.yml
+++ b/.github/workflows/wporg-validator.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         php-version: "8.4"
         extensions: mysqli
-        tools: composer,wp-cli
+        tools: composer:2.8,wp-cli
 
     - name: Cache Composer dependencies
       uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
@@ -38,7 +38,7 @@ jobs:
 
     - name: Create Dist Archive for wp.org validation
       run: |
-        wp package install wp-cli/dist-archive-command
+        wp package install wp-cli/dist-archive-command:v3.1.0
         wp dist-archive . --plugin-dirname=wp-redis --filename-format=wp-redis-dist
         unzip ../wp-redis-dist.zip
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WP Redis #
 [![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#actively-maintained)
 
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [mboynes](https://profiles.wordpress.org/mboynes), [Outlandish Josh](https://profiles.wordpress.org/outlandish-josh) [jspellman](https://profiles.wordpress.org/jspellman/) [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/)  
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [mboynes](https://profiles.wordpress.org/mboynes), [Outlandish Josh](https://profiles.wordpress.org/outlandish-josh) [jspellman](https://profiles.wordpress.org/jspellman/) [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [anaispantheor](https://profiles.wordpress.org/anaispantheor/), [metasim](https://profiles.wordpress.org/metasim/)  
 **Tags:** cache, object-cache, redis  
 **Requires at least:** 3.0.1  
 **Tested up to:** 6.9  
@@ -110,7 +110,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 ## Changelog ##
 
 ### 1.4.8-dev ###
-* PHP 8.5 compatibility [[#XXX](https://github.com/pantheon-systems/wp-redis/pull/XXX)]
+* PHP 8.5 compatibility [[#551](https://github.com/pantheon-systems/wp-redis/pull/551)]
 
 ### 1.4.7 (December 2, 2025) ###
 * WordPress 6.9 compatibility [[#524](https://github.com/pantheon-systems/wp-redis/pull/524)]

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ There's a known issue with WordPress `alloptions` cache design. Specifically, a 
 ## Changelog ##
 
 ### 1.4.8-dev ###
+* PHP 8.5 compatibility [[#XXX](https://github.com/pantheon-systems/wp-redis/pull/XXX)]
 
 ### 1.4.7 (December 2, 2025) ###
 * WordPress 6.9 compatibility [[#524](https://github.com/pantheon-systems/wp-redis/pull/524)]

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,16 @@
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "pantheon-systems/wpunit-helpers": true
+    },
+    "audit": {
+      "ignore": {
+        "PKSA-z3gr-8qht-p93v": "Dev-only: phpunit/phpunit (test runner). No prod exposure. SITE-5206.",
+        "PKSA-5r1g-c7b7-y1zg": "Dev-only: symfony/dom-crawler via behat test deps. No prod exposure. SITE-5206.",
+        "PKSA-dwsq-ppd2-mb1x": "Dev-only: symfony/polyfill-intl-idn via behat test deps. No prod exposure. SITE-5206.",
+        "PKSA-v5yj-8nmz-sk2q": "Dev-only: symfony/yaml via behat test deps. No prod exposure. SITE-5206.",
+        "PKSA-ft77-7h5f-p3r6": "Dev-only: symfony/yaml via behat test deps. No prod exposure. SITE-5206.",
+        "PKSA-b14r-zh1d-vdrc": "Dev-only: symfony/yaml via behat test deps. No prod exposure. SITE-5206."
+      }
     }
   },
   "autoload": {

--- a/object-cache.php
+++ b/object-cache.php
@@ -444,6 +444,20 @@ class WP_Object_Cache {
 	public $last_triggered_error = '';
 
 	/**
+	 * The Redis client instance
+	 *
+	 * @var Redis|Relay\Relay
+	 */
+	public $redis;
+
+	/**
+	 * Message describing why Redis is unavailable
+	 *
+	 * @var string
+	 */
+	public $missing_redis_message = '';
+
+	/**
 	 * Whether or not to use true cache groups, instead of flattening.
 	 *
 	 * @var bool

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === WP Redis ===
-Contributors: getpantheon, danielbachhuber, mboynes, Outlandish Josh, jspellman, jazzs3quence
+Contributors: getpantheon, danielbachhuber, mboynes, Outlandish Josh, jspellman, jazzs3quence, anaispantheor, metasim
 Tags: cache, object-cache, redis
 Requires at least: 3.0.1
 Tested up to: 6.9
@@ -107,7 +107,7 @@ Please report security bugs found in the source code of the WP Redis plugin thro
 == Changelog ==
 
 = 1.4.8-dev =
-* PHP 8.5 compatibility
+* PHP 8.5 compatibility [[#551](https://github.com/pantheon-systems/wp-redis/pull/551)]
 
 = 1.4.7 (December 2, 2025) =
 * WordPress 6.9 compatibility [[#524](https://github.com/pantheon-systems/wp-redis/pull/524)]

--- a/readme.txt
+++ b/readme.txt
@@ -107,6 +107,7 @@ Please report security bugs found in the source code of the WP Redis plugin thro
 == Changelog ==
 
 = 1.4.8-dev =
+* PHP 8.5 compatibility
 
 = 1.4.7 (December 2, 2025) =
 * WordPress 6.9 compatibility [[#524](https://github.com/pantheon-systems/wp-redis/pull/524)]


### PR DESCRIPTION
## Summary

- Declare `$redis` and `$missing_redis_message` as explicit class properties in `WP_Object_Cache` (`object-cache.php`). These were previously assigned dynamically via `$this->redis = ...` and `$this->missing_redis_message = ...` inside methods, which triggers an `E_DEPRECATED` warning in PHP 8.2+.
- Add PHP 8.5 to the CI test matrix (`lint-test.yml`).

Replaces #541.

## Context

PHP 8.2 deprecated dynamic property creation on classes. This remains a deprecation in PHP 8.5 (not promoted to an error as some sources suggest). Declaring the properties explicitly eliminates the deprecation warning and future-proofs the plugin for PHP 9.0, where dynamic properties are expected to become a hard error.

This is the same pattern applied across other SiteX plugins (wp-saml-auth, wp-native-php-sessions, PAPC).

## Testing

### Live testing on Pantheon PHP 8.5

Tested on `wp-sitex-august.php85` multidev (PHP 8.5.6):

1. **Confirmed PHP version:** `phpversion()` returns `8.5.6`.

2. **Verified dynamic property behavior on PHP 8.5:**
   - Dynamic property assignment on user classes triggers `E_DEPRECATED` (error code 8192), not `ErrorException`.
   - PHP 8.5 does NOT promote dynamic properties to errors; they remain deprecation warnings, same as 8.2-8.4.

3. **Tested wp-redis 1.4.7 (without fix) on PHP 8.5:**
   - Installed wp-redis from wp.org, enabled the object-cache drop-in.
   - `wp_cache_set` / `wp_cache_get` work correctly.
   - Redis connects successfully (`is_redis_connected: true`).
   - No errors in PHP error log from web requests or WP-CLI.
   - `$redis` is dynamically created during `_connect_redis()` bootstrap; `$missing_redis_message` is never assigned when Redis connects.

4. **Conclusion:** wp-redis functions on PHP 8.5 without the fix, but the undeclared properties generate silent `E_DEPRECATED` warnings. Declaring them is standard hygiene to eliminate deprecations and prepare for PHP 9.0.

### CI

PHP 8.5 added to the test matrix. CI runs against PHP 7.4, 8.2, 8.3, 8.4, and 8.5 with Redis both enabled and disabled.

Ref: SITE-5206