### PR TITLE
[SITE-5793] Fix script injection in Behat test workflow

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -50,6 +50,9 @@ jobs:
     services:
       mariadb:
         image: mariadb:${{ (matrix.php_version == '7.4') && '10.5' || '10.6' }}
+        # Newer MariaDB images require a password setting to start; empty root is fine here since this container is ephemeral, unexposed, and holds no real data.
+        env:
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
       redis:
         image: redis:6.2
         ports:

--- a/.github/workflows/test-behat.yml
+++ b/.github/workflows/test-behat.yml
@@ -62,10 +62,10 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SITE_OWNER_SSH_PRIVATE_KEY }}
 
-      # Configures Composer with the GitHub token for accessing private repositories.
-      # The GITHUB_TOKEN is automatically provided by GitHub Actions.
       - name: Configure GitHub Token for Composer
-        run: composer config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: composer config -g github-oauth.github.com "$GH_TOKEN"
 
       - name: Validate fixture version
         uses: jazzsequence/action-validate-plugin-version@6b8b403af6e9eefde9c36c0d342b717d5952b518 # v2.0.1

--- a/.github/workflows/test-behat.yml
+++ b/.github/workflows/test-behat.yml
@@ -62,11 +62,6 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - name: Configure GitHub Token for Composer
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: composer config -g github-oauth.github.com "$GH_TOKEN"
-
       - name: Validate fixture version
         uses: jazzsequence/action-validate-plugin-version@6b8b403af6e9eefde9c36c0d342b717d5952b518 # v2.0.1
         with:


### PR DESCRIPTION
## Summary

- Move `${{ secrets.GITHUB_TOKEN }}` from `run:` block to `env:` block in test-behat.yml
- Remove the unneeded "Configure GitHub Token for Composer" step entirely — none of this repo's Composer dependencies are private, so no authenticated GitHub access is needed
- Fix the `mariadb` service container failing to start in the `Test` matrix jobs (unrelated pre-existing bug, not caused by this PR)

## Why

Using `${{ }}` expressions directly inside `run:` blocks is a script injection vulnerability. Secrets interpolated into shell scripts can leak through error messages or shell tracing. The secure pattern is to pass them through `env:` blocks.

Removing the Composer token step: checked `composer.json` — all dependencies are public Packagist packages or public GitHub repos, so this step never needed authenticated access in the first place.

The `mariadb` service fix: newer `mariadb:10.5`/`10.6` images refuse to start without an explicit password setting. This block hasn't changed since 2023, so this broke on its own as the floating image tag picked up a newer MariaDB build over time, not from any code change here. Empty root password is fine — the container is ephemeral, not exposed outside the job, and holds no real data.

## Current blocker

`Test` jobs still fail after the MariaDB fix, on a separate, unrelated issue: a Composer dependency conflict between this repo's `behat/mink-goutte-driver ^1.2` and `pantheon-systems/pantheon-wordpress-upstream-tests` (dev-master), which now requires `behat/mink-browserkit-driver ^2.1` since [pantheon-wordpress-upstream-tests#82](https://github.com/pantheon-systems/pantheon-wordpress-upstream-tests/pull/82) (SITE-5774).

[PR #562](https://github.com/pantheon-systems/wp-redis/pull/562) (Phil Tyler) fixes this by swapping this repo's own Goutte driver for BrowserKit, matching the upstream change — all its checks are already green. That PR needs to merge first; this PR should be rebased on top of it afterward to pick up the fix.

## Test plan

- [x] Verify Behat tests still authenticate with Composer and run successfully — `test-behat` passes
- [ ] Verify the `Test` matrix jobs pass with the MariaDB fix (blocked on #562 merging first)