### PR TITLE
[SITE-6002] Fix CodeQL alerts

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,6 +1,8 @@
 # On push, run the action-wporg-validator workflow.
 name: Linting & Test
 on: [push]
+permissions:
+  contents: read
 jobs:
   validate-readme-spacing:
     name: Validate README Spacing

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -3,6 +3,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes all 5 open CodeQL alerts (missing workflow permissions) by adding explicit `permissions:` blocks with least-privilege scopes to two workflow files.

**lint-test.yml** (alerts #52, #53, #54, #56): Added top-level `permissions: contents: read`. All four jobs (validate-readme-spacing, lint, php8-compatibility, test) only check out code, run linters, and execute tests. No steps write to PRs, push code, or interact with the GitHub API beyond reading.

**wordpress-plugin-deploy.yml** (alert #55): Added top-level `permissions: contents: read`. The deploy job checks out code and pushes to wp.org SVN using repository secrets (SVN_USERNAME/SVN_PASSWORD), not the GITHUB_TOKEN. No GitHub API write access needed.

Without explicit permissions, workflows inherit the default token permissions (which may include write access to contents, packages, issues, etc.). Setting `contents: read` restricts the GITHUB_TOKEN to read-only, following the principle of least privilege.