### PR TITLE
chore(deps): [VUL-24493 et al] audit-ignore guzzle and psr7 advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,9 @@
         "PKSA-dwsq-ppd2-mb1x": "Dev-only: symfony/polyfill-intl-idn via behat test deps. No prod exposure. SITE-5206.",
         "PKSA-v5yj-8nmz-sk2q": "Dev-only: symfony/yaml via behat test deps. No prod exposure. SITE-5206.",
         "PKSA-ft77-7h5f-p3r6": "Dev-only: symfony/yaml via behat test deps. No prod exposure. SITE-5206.",
-        "PKSA-b14r-zh1d-vdrc": "Dev-only: symfony/yaml via behat test deps. No prod exposure. SITE-5206."
+        "PKSA-b14r-zh1d-vdrc": "Dev-only: symfony/yaml via behat test deps. No prod exposure. SITE-5206.",
+        "PKSA-bcdd-5xc7-gwfb": "Dev-only: guzzlehttp/guzzle via behat test deps (fabpot/goutte pins ^6, no 6.x patch exists). No prod exposure. VUL-24493.",
+        "PKSA-vznr-tgp9-fd7d": "Dev-only: guzzlehttp/psr7 via behat test deps (guzzle 6 pins psr7 ^1.9, no 1.x patch exists). No prod exposure. VUL-25208."
       }
     }
   },


### PR DESCRIPTION
## Summary

- Added two `config.audit.ignore` entries to `composer.json` for CVE-2026-59883 (`guzzlehttp/guzzle`, advisory `PKSA-bcdd-5xc7-gwfb`) and CVE-2026-59882 (`guzzlehttp/psr7`, advisory `PKSA-vznr-tgp9-fd7d`)
- Both packages are dev-only, reaching the lock only through `require-dev: behat/mink-goutte-driver ^1.2 -> fabpot/goutte v3.3.1 -> guzzlehttp/guzzle 6.5.8 -> guzzlehttp/psr7 1.9.1`
- The upstream advisories have no patched 6.x (guzzle) or 1.x (psr7) releases; the only fix versions are 7.12.3 and 2.12.3 respectively, which are major version jumps that `fabpot/goutte ^3` cannot satisfy

## Context

[VUL-24493](https://getpantheon.atlassian.net/browse/VUL-24493) | [VUL-25208](https://getpantheon.atlassian.net/browse/VUL-25208)

Both tickets are GHAS Dependabot scans flagging dev-only transitive deps with no available patch in the installed major version line. The ratified remediation route (2026-07-28) is audit-ignore since no production exposure exists.

**No patched line verification (GitHub Advisory DB):**
- GHSA-g446-98w2-8p5w (`guzzlehttp/guzzle`): affected range `< 7.12.3`; no 6.x entry. Guzzle 6.x has no patched release.
- GHSA-c2w2-prh8-qm98 (`guzzlehttp/psr7`): affected range `< 2.12.3`; no 1.x entry. PSR-7 1.x has no patched release.

**Prior work on these tickets:**
- PR #556 (`service-samwise`, open): takes a migration approach, replacing `fabpot/goutte` with the Symfony BrowserKit driver to remove guzzle entirely. That is a different, larger change. This PR is the simpler audit-ignore route as ratified.
- Branch `fix/SITE-5995-composer-auth-fix` (local): added audit-ignore entries for the same guzzle dep chain using SITE-5995 as the ticket reference, but was not pushed/merged and does not cover the psr7 advisories introduced in VUL-25208.

## Release

No release needed. These changes are dev-only: `composer.json` has no `require` section (production deps are empty). All affected packages enter the lock exclusively via `require-dev`. Shipping a new plugin version would include zero behavioral change; the ignore entries are a build-tooling config only.

Evidence from `composer.json`:
```
"require-dev": {
  "behat/behat": "^3.1",
  "behat/mink-extension": "^2.2",
  "behat/mink-goutte-driver": "^1.2",
  ...
}
```
There is no `require` key. The plugin's runtime code has no guzzle or psr7 dependency.

## Test plan

- [x] `composer install` completes cleanly
- [x] `composer audit --format=json` confirms `PKSA-bcdd-5xc7-gwfb` (CVE-2026-59883) and `PKSA-vznr-tgp9-fd7d` (CVE-2026-59882) appear in the `ignored-advisories` output
- [x] Dev-only chain verified via `composer.lock`: both packages are in the `packages-dev` section; `require` is empty
- [x] `composer validate` exits clean for simple usage (pre-existing strict warning: missing `description` field, not introduced by this PR)
- [x] Commit is GPG-signed (YubiKey, RSA key `6EA570AA8670FE4746CFA07B2D611B67C6E7BC99`)

**Pre-existing active advisories not addressed by this PR** (all dev-only, same chain, separate scope):
- `guzzlehttp/guzzle`: PKSA-fy2t-3c5f-827y, PKSA-qxvb-2bpp-dnk6, PKSA-bbs6-q5q9-f3t4, PKSA-pwsk-hy21-4gby, PKSA-93qv-9n9h-6k6p (CVE-2026-55767), PKSA-k22t-f949-t9g6 (CVE-2026-55568)
- `guzzlehttp/psr7`: PKSA-7qs6-zvnz-h66r (CVE-2026-55766), PKSA-gm5x-j3mz-71n9 (CVE-2026-49214), PKSA-jj5t-2zs1-dcfm (CVE-2026-48998)
- `wp-coding-standards/wpcs`: PKSA-mh9b-91zm-m1gy (CVE-2026-45293) (also dev-only via `pantheon-systems/pantheon-wp-coding-standards`)

These are all pre-existing on `main` and are either tracked in SITE-5995 or require a separate ticket.

## References

- Jira: [VUL-24493](https://getpantheon.atlassian.net/browse/VUL-24493) | [VUL-25208](https://getpantheon.atlassian.net/browse/VUL-25208)
- Related PR (competing approach): pantheon-systems/wp-redis#556
- Advisory: [GHSA-g446-98w2-8p5w](https://github.com/advisories/GHSA-g446-98w2-8p5w) | [GHSA-c2w2-prh8-qm98](https://github.com/advisories/GHSA-c2w2-prh8-qm98)


[VUL-24493]: https://getpantheon.atlassian.net/browse/VUL-24493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VUL-25208]: https://getpantheon.atlassian.net/browse/VUL-25208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VUL-24493]: https://getpantheon.atlassian.net/browse/VUL-24493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ