### PR TITLE
chore: group dependabot minor/patch updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
       day: tuesday
     target-branch: "main"
     open-pull-requests-limit: 99
+    groups:
+      composer-minor-patch:
+        update-types:
+        - minor
+        - patch
     ignore:
     - dependency-name: phpunit/phpunit
       versions:
@@ -21,3 +26,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Composer minor/patch updates and github-actions updates are now grouped into a single PR per ecosystem, matching the convention used in pantheon-hud. Major version bumps for composer dependencies still open as individual PRs.