### PR TITLE
SITE-5791: pin actions to Node 24 release SHAs

### DIFF
--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Build, tag, and release
-      uses: pantheon-systems/plugin-release-actions/build-tag-release@a3839d25efa9d0d4270c088702c2072a2e49edde # v0.5.0
+      uses: pantheon-systems/plugin-release-actions/build-tag-release@8c76f0613b094d9812da9257030e534c4d8eeb6c # v0.5.6
       with:
         gh_token: ${{ secrets.GITHUB_TOKEN }}
         generate_release_notes: "true"

--- a/.github/workflows/composer-diff.yml
+++ b/.github/workflows/composer-diff.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Generate composer diff
         id: composer_diff
         uses: IonBazan/composer-diff-action@3140157575f6a67799cc80248ae35f5fb303ab15 # v1.2.0
-      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         if: ${{ steps.composer_diff.outputs.composer_diff_exit_code != 0 }}
         with:
           header: composer-diff

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -24,7 +24,7 @@ jobs:
         key: test-lint-dependencies-{{ checksum "composer.json" }}
         restore-keys: test-lint-dependencies-{{ checksum "composer.json" }}
     - name: Setup PHP
-      uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: 8.3
     - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php_version }}
           extensions: mysqli, zip, imagick, redis

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Create Draft Release PR
-        uses: pantheon-systems/plugin-release-actions/release-pr@a3839d25efa9d0d4270c088702c2072a2e49edde # main 2025-11-07T23:23:14Z
+        uses: pantheon-systems/plugin-release-actions/release-pr@8c76f0613b094d9812da9257030e534c4d8eeb6c # v0.5.6
         with:
           gh_token: ${{ github.token }}
           readme_md: README.md

--- a/.github/workflows/test-behat.yml
+++ b/.github/workflows/test-behat.yml
@@ -58,7 +58,7 @@ jobs:
         run: echo "GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" >> $GITHUB_ENV
 
       - name: Install SSH key
-        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/test-behat.yml
+++ b/.github/workflows/test-behat.yml
@@ -37,7 +37,7 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Install Terminus
-        uses: pantheon-systems/terminus-github-actions@8e024bd89ff46ed2aa4e0663c6b54c87a94344f8 # v1.2.7
+        uses: pantheon-systems/terminus-github-actions@b0a005d0e886678b25cb6cd7833cf8d8cf779900 # v1.2.9
         with:
           pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
 

--- a/.github/workflows/wporg-validator.yml
+++ b/.github/workflows/wporg-validator.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
     - name: Setup PHP 8.4
-      uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: "8.4"
         extensions: mysqli


### PR DESCRIPTION
GitHub removes Node.js 20 from the runners on 16 September 2026.

This pins every affected action reference in this repo to the commit SHA of a Node 24 release, with the version as a trailing comment. That covers both halves of SITE-5791 in one edit: the SHA pin removes the risk of a tag being repointed at a different commit, and the release bump clears the Node 20 removal.

Pinning `@v4` would not have been enough: v4 of `actions/checkout` and `actions/cache` runs on Node 20 itself, so each reference needed both a SHA and a version bump.

| File | Was | Now | Old runtime |
|---|---|---|---|
| `.github/workflows/composer-diff.yml` | `marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405` | `marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5` | node20 |
| `.github/workflows/lint-test.yml` | `shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1` | `shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2` | node20 |
| `.github/workflows/lint-test.yml` | `shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1` | `shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2` | node20 |
| `.github/workflows/test-behat.yml` | `webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd` | `webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0` | node20 |
| `.github/workflows/wporg-validator.yml` | `shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1` | `shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2` | node20 |

Part of SITE-5791, under the CI standardization epic SITE-5778.

---

### Supersedes pending Dependabot PRs

This PR changes the same `uses:` lines as #566, now closed to avoid conflicting edits. Dependabot preserves whatever reference style it finds -- it bumps a tag to a newer tag and does not convert `@v4` into a SHA pin. The pinning has to happen here; Dependabot maintains the SHAs afterwards.


